### PR TITLE
Implement service worker precaching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,29 @@
-self.addEventListener('install', event => self.skipWaiting());
-self.addEventListener('activate', event => event.waitUntil(clients.claim()));
+const CACHE_NAME = 'precache-v1';
+const PRECACHE_URLS = [
+  './',
+  'index.html',
+  'style.css',
+  'app.js',
+  'dados.js',
+  'manifest.json',
+  'icon-192.png',
+  'icon-512.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim());
+});
+
 self.addEventListener('fetch', event => {
-  event.respondWith(fetch(event.request).catch(() => caches.match(event.request)));
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    fetch(event.request).catch(() => caches.match(event.request))
+  );
 });


### PR DESCRIPTION
## Summary
- preload critical assets during service worker install
- cache requests when the network is unavailable

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6848fb4e7728832c97d679663632b64e