### PR TITLE
Configura testes e CI com Jest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,40 @@
+const { gerarTreino, calcularSequenciaDias, __setDadosTreinos } = require('../app');
+
+describe('calcularSequenciaDias', () => {
+  test('calcula maior sequencia', () => {
+    const datas = ['2023-01-01', '2023-01-02', '2023-01-04', '2023-01-05', '2023-01-06'];
+    expect(calcularSequenciaDias(datas)).toBe(3);
+  });
+});
+
+describe('gerarTreino', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <input id="tempo" value="30" />
+      <select id="intensidade"><option value="media" selected>media</option></select>
+      <div id="treino"></div>
+    `;
+    localStorage.setItem('perfil_usuario', JSON.stringify({equipamento: [], locais:['Casa']}));
+    __setDadosTreinos({
+      core: [
+        {nome:'ex1', equipamentos:[], objetivo:['forca'], exclusivoAcademia:false},
+        {nome:'ex2', equipamentos:[], objetivo:['forca'], exclusivoAcademia:false},
+        {nome:'ex3', equipamentos:[], objetivo:['forca'], exclusivoAcademia:false}
+      ]
+    });
+    global.grupoSugerido = 'core';
+    global.mostrarTreino = jest.fn();
+  });
+
+  test('cria entrada no localStorage para o treino', () => {
+    gerarTreino();
+    const dia = new Date().toISOString().slice(0,10);
+    const chave = `treino_${dia}core`;
+    const stored = JSON.parse(localStorage.getItem(chave));
+    expect(stored).toBeTruthy();
+    expect(stored.grupo).toBe('core');
+    expect(stored.tempo).toBe(30);
+    expect(mostrarTreino).toHaveBeenCalled();
+  });
+});

--- a/app.js
+++ b/app.js
@@ -426,4 +426,14 @@ window.onload = async () => {
 
 };
 
-// 🔄 Carregar dados ao iniciar  
+// 🔄 Carregar dados ao iniciar
+
+// Exports para testes em ambiente Node
+if (typeof module !== 'undefined') {
+  module.exports = {
+    gerarTreino,
+    calcularSequenciaDias,
+    embaralharArray,
+    __setDadosTreinos: d => dadosTreinos = d
+  };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cavernabjj",
+  "version": "1.0.0",
+  "description": "Test setup",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Resumo
- adiciona `package.json` com Jest
- cria configuração do Jest
- exporta funções do `app.js` para testes
- cria testes básicos para `calcularSequenciaDias` e `gerarTreino`
- configura GitHub Actions para rodar testes

## Testes
- `npm test` *(falha: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6848fbce212c832c85de6591cc07049a