### PR TITLE
Add manual group selection feature

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -13,6 +13,7 @@ describe('gerarTreino', () => {
     document.body.innerHTML = `
       <input id="tempo" value="30" />
       <select id="intensidade"><option value="media" selected>media</option></select>
+      <select id="grupoSelect"><option value="core" selected>core</option></select>
       <div id="treino"></div>
     `;
     localStorage.setItem('perfil_usuario', JSON.stringify({equipamento: [], locais:['Casa']}));

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ let dadosTreinos = {};
 
 async function carregarDados() {
     dadosTreinos = await getDados();
+    popularSelectGrupo();
     const hoje = new Date().toISOString().slice(0, 10);
 
     if (hasTreinoHoje()) {
@@ -59,7 +60,15 @@ async function salvarPerfil() {
     alert("Perfil salvo com sucesso!");
 
     await iniciar(perfil);
-    
+
+}
+
+function popularSelectGrupo() {
+    const sel = document.getElementById("grupoSelect");
+    if (!sel) return;
+    sel.innerHTML = Object.keys(dadosTreinos)
+        .map(g => `<option value="${g}">${g.toUpperCase()}</option>`)
+        .join("");
 }
 
 function editarPerfil() {
@@ -141,6 +150,8 @@ async function sugerirGrupo() {
     const escolhido = empatados[Math.floor(Math.random() * empatados.length)].grupo;
 
     window.grupoSugerido = escolhido;
+    const selGrupo = document.getElementById("grupoSelect");
+    if (selGrupo) selGrupo.value = escolhido;
 
     let saida = `<h3>📌 Grupo Sugerido: ${escolhido.toUpperCase()}</h3>`;
     saida += `<p>📅 <strong> Treinos Recentes:</strong> ${cooldown.join(", ") || "nenhum"}</p>`;
@@ -162,7 +173,8 @@ function limparTreino() {
 function gerarTreino() {
     const tempo = parseInt(document.getElementById("tempo").value);
     const intensidade = document.getElementById("intensidade").value;
-    const grupo = window.grupoSugerido || "core";
+    const sel = document.getElementById("grupoSelect");
+    const grupo = sel && sel.value ? sel.value : (window.grupoSugerido || "core");
     const dia = new Date().toISOString().slice(0, 10);
     const chave = "treino_" + dia + grupo;
     const perfil = getPerfil();

--- a/index.html
+++ b/index.html
@@ -101,6 +101,10 @@
           <option value="intensa">Intensa</option>
         </select>
       </div>
+      <div style="flex: 1; min-width: 180px;">
+        <label for="grupoSelect"><strong>🏋️ Grupo:</strong></label>
+        <select id="grupoSelect" onchange="gerarTreino()"></select>
+      </div>
 
     </div>
 


### PR DESCRIPTION
## Summary
- support user selectable group for training
- default to recommended group but allow override
- update tests for new group dropdown

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68806e55b884832cbb4f2d9bc1be1a7c