### PR TITLE
Reposiciona botão de tema no cabeçalho

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 
-  <body>
-    <button id="toggleTema" onclick="alternarTema()" aria-label="Alternar tema">🌙</button>
-    <div class="app-header">
-      <img src="icon-192.png" alt="Ícone do app" class="app-icon" />
-      <h1>Caverna BJJ</h1>
-    </div>
+    <body>
+      <div class="app-header">
+        <img src="icon-192.png" alt="Ícone do app" class="app-icon" />
+        <h1>Caverna BJJ</h1>
+        <button id="toggleTema" onclick="alternarTema()" aria-label="Alternar tema">🌙</button>
+      </div>
 
 
   <!-- Card de Configuração de Perfil -->

--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ h1 {
 }
 
 .app-header {
+    position: relative;
     text-align: center;
     margin-bottom: 20px;
 }
@@ -292,14 +293,18 @@ strong {
   
 /* Botão de troca de tema */
 #toggleTema {
-    position: fixed;
+    position: absolute;
     top: 10px;
     right: 10px;
     background: transparent;
     border: none;
     font-size: 20px;
     cursor: pointer;
-    z-index: 1000;
+    color: #002b5c;
+}
+
+body.dark #toggleTema {
+    color: #79baff;
 }
 
 /* Estilos para modo escuro */


### PR DESCRIPTION
## Resumo
- Move botão de alternância de tema para dentro do cabeçalho
- Ajusta layout do cabeçalho para posicionar botão com `position: absolute`
- Harmoniza cores do botão entre temas claro e escuro

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c24114c4a4832c8bbca4f70927f49e