### PR TITLE
Limitar grupos pelo tempo de treino

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -32,17 +32,29 @@ describe('gerarTreino', () => {
     global.grupoSugerido = 'core';
   });
 
-  test('cria entrada no localStorage para o treino', () => {
-    gerarTreino();
-    const dia = new Date().toISOString().slice(0,10);
-    const chave = `treino_${dia}`;
-    const stored = JSON.parse(localStorage.getItem(chave));
-    expect(stored).toBeTruthy();
-    expect(stored.grupos.length).toBe(2);
-    expect(stored.grupos).toEqual(expect.arrayContaining(['core','cardio']));
-    const nomes = stored.lista.map(e => e.nome);
-    expect(new Set(nomes).size).toBe(nomes.length);
-    expect(stored.tempo).toBe(30);
-    expect(document.getElementById('treino').innerHTML).not.toBe('');
+    test('cria entrada no localStorage para o treino', () => {
+      gerarTreino();
+      const dia = new Date().toISOString().slice(0,10);
+      const chave = `treino_${dia}`;
+      const stored = JSON.parse(localStorage.getItem(chave));
+      expect(stored).toBeTruthy();
+      expect(stored.grupos.length).toBe(2);
+      expect(stored.grupos).toEqual(expect.arrayContaining(['core','cardio']));
+      const nomes = stored.lista.map(e => e.nome);
+      expect(new Set(nomes).size).toBe(nomes.length);
+      expect(stored.tempo).toBe(30);
+      expect(document.getElementById('treino').innerHTML).not.toBe('');
+    });
+
+    test('limita grupos conforme tempo disponível', () => {
+      document.getElementById('tempo').value = '15';
+      const sel = document.getElementById('grupoSelect');
+      sel.options[0].selected = true;
+      sel.options[1].selected = true;
+      gerarTreino();
+      const dia = new Date().toISOString().slice(0,10);
+      const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
+      expect(stored.grupos.length).toBe(1);
+      expect(stored.grupos[0]).toBe('core');
+    });
   });
-});

--- a/app.js
+++ b/app.js
@@ -207,6 +207,25 @@ function ajustarProgressao(tempo, intensidade) {
     return { tempo, intensidade };
 }
 
+function limitarSelecaoGrupos() {
+    const tempo = parseInt(document.getElementById("tempo").value) || 0;
+    const limite = Math.max(1, Math.floor(tempo / 15));
+    const sel = document.getElementById("grupoSelect");
+    if (!sel) return [];
+    let selecionados = Array.from(sel.selectedOptions);
+    if (selecionados.length > limite) {
+        selecionados.slice(limite).forEach(o => o.selected = false);
+        const isJsdom = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+        if (typeof alert === 'function' && !isJsdom) {
+            try {
+                alert(`Para ${tempo} minutos, selecione no máximo ${limite} grupos.`);
+            } catch (e) {}
+        }
+        selecionados = Array.from(sel.selectedOptions);
+    }
+    return selecionados.map(o => o.value);
+}
+
 // ✅ Gerar treino
 function gerarTreino() {
     let tempo = parseInt(document.getElementById("tempo").value);
@@ -216,10 +235,10 @@ function gerarTreino() {
     intensidade = ajustados.intensidade;
     document.getElementById("tempo").value = tempo;
     document.getElementById("intensidade").value = intensidade;
-    const sel = document.getElementById("grupoSelect");
-    const grupos = sel && sel.selectedOptions.length
-        ? Array.from(sel.selectedOptions).map(o => o.value)
-        : [window.grupoSugerido || "core"]; // fallback
+    let grupos = limitarSelecaoGrupos();
+    if (!grupos.length) {
+        grupos = [window.grupoSugerido || "core"]; // fallback
+    }
     const dia = new Date().toISOString().slice(0, 10);
     const chave = "treino_" + dia;
     const perfil = getPerfil();

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
     <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;">
       <div style="flex: 1; min-width: 180px;">
         <label for="tempo"><strong>⏱️ Tempo disponível:</strong></label>
-        <select id="tempo" onchange="gerarTreino()">
+        <select id="tempo" onchange="limitarSelecaoGrupos(); gerarTreino()">
           <option value="15">15 min</option>
           <option value="30" selected>30 min</option>
           <option value="45">45 min</option>
@@ -106,7 +106,7 @@
       </div>
       <div style="flex: 1; min-width: 180px;">
         <label for="grupoSelect"><strong>🏋️ Grupo:</strong></label>
-        <select id="grupoSelect" multiple size="5" onchange="gerarTreino()">
+        <select id="grupoSelect" multiple size="5" onchange="limitarSelecaoGrupos(); gerarTreino()">
           <option value="cardio">CARDIO</option>
           <option value="core">CORE</option>
           <option value="dedos">DEDOS</option>


### PR DESCRIPTION
## Summary
- restringe quantidade de grupos selecionados de acordo com o tempo disponível, com 1 grupo a cada 15 minutos
- aciona a validação sempre que o tempo ou os grupos são alterados
- cobre cenário de limite de grupos em testes automatizados

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2511905ac832cbb56561cfd231f83