### PR TITLE
feat: confirmar limpeza ao sugerir novo grupo

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,4 +1,4 @@
-const { gerarTreino, calcularSequenciaDias, __setDadosTreinos } = require('../app');
+const { gerarTreino, calcularSequenciaDias, __setDadosTreinos, sugerirGrupo } = require('../app');
 
 describe('calcularSequenciaDias', () => {
   test('calcula maior sequencia', () => {
@@ -56,5 +56,22 @@ describe('gerarTreino', () => {
       const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
       expect(stored.grupos.length).toBe(1);
       expect(stored.grupos[0]).toBe('core');
-    });
   });
+});
+
+describe('sugerirGrupo', () => {
+  test('pede confirmação ao limpar múltiplos grupos selecionados', async () => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <select id="grupoSelect" multiple>
+        <option value="core" selected>core</option>
+        <option value="cardio" selected>cardio</option>
+      </select>
+    `;
+
+    const spy = jest.spyOn(global, 'confirm').mockReturnValue(false);
+    await sugerirGrupo();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/app.js
+++ b/app.js
@@ -109,6 +109,15 @@ function getUltimosTreinos() {
 }
 
 async function sugerirGrupo() {
+    const selGrupo = document.getElementById("grupoSelect");
+    if (selGrupo) {
+        const selecionados = Array.from(selGrupo.selectedOptions);
+        if (selecionados.length > 1) {
+            const confirmar = confirm("Mais de um grupo está selecionado. Sugerir outro grupo irá limpar a seleção atual. Deseja continuar?");
+            if (!confirmar) return;
+        }
+    }
+
     const cooldown = getUltimosTreinos();
     const score = {};
 
@@ -160,7 +169,6 @@ async function sugerirGrupo() {
     const escolhido = empatados[Math.floor(Math.random() * empatados.length)].grupo;
 
     window.grupoSugerido = escolhido;
-    const selGrupo = document.getElementById("grupoSelect");
     if (selGrupo) {
         Array.from(selGrupo.options).forEach(o => o.selected = o.value === escolhido);
     }
@@ -520,6 +528,7 @@ if (typeof module !== 'undefined') {
     gerarTreino,
     calcularSequenciaDias,
     embaralharArray,
+    sugerirGrupo,
     __setDadosTreinos: d => dadosTreinos = d
   };
 }


### PR DESCRIPTION
## Summary
- solicita confirmação ao sugerir novo grupo com múltiplos grupos selecionados
- exporta `sugerirGrupo` e adiciona teste

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25617ef60832caf18a97c82c8a3a7