### PR TITLE
Organiza exercícios de braço e amplia grupos

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,7 @@ async function salvarPerfil() {
 function popularSelectGrupo() {
     const sel = document.getElementById("grupoSelect");
     if (!sel) return;
-    const nomes = { bracos: 'Braços' };
+    const nomes = { biceps: 'Bíceps', triceps: 'Tríceps' };
     sel.innerHTML = Object.keys(dadosTreinos)
         .sort()
         .map(g => {

--- a/exercicios.json
+++ b/exercicios.json
@@ -1,909 +1,1384 @@
 {
-        "ombro": [
-            {
-                "nome": "Wall Angels (3x15)",
-                "subgrupo": "mobilidade",
-                "equipamentos": [],
-                "objetivo": ["mobilidade", "jiujitsu"],
-                "peso": 1,
-                "descricao": "Fique encostado na parede, com braços dobrados a 90°, deslize-os para cima e para baixo sem tirar as costas da parede.",
-                "video": "https://www.youtube.com/watch?v=Im3DTNGjMJo",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Shrug com halteres (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Segure os halteres ao lado do corpo e eleve os ombros como se estivesse tentando tocar as orelhas.",
-                "video": "https://www.youtube.com/watch?v=pYcpY20QaE8",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Elevação lateral (2x15)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca", "mobilidade"],
-                "peso": 3,
-                "descricao": "Com halteres nas mãos, levante os braços lateralmente até a altura dos ombros e volte lentamente.",
-                "video": "https://www.youtube.com/watch?v=3VcKaXpzqRo",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Rotação externa com elástico (3x15)",
-                "subgrupo": "reabilitação",
-                "equipamentos": ["elastico"],
-                "objetivo": ["mobilidade"],
-                "peso": 1,
-                "descricao": "Com o braço colado ao corpo, gire o antebraço para fora contra a resistência do elástico.",
-                "video": "https://www.youtube.com/watch?v=BYNR86w3Ww8",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Frontal raise com halteres (2x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Erga os halteres à frente do corpo até a altura dos ombros, mantendo os braços estendidos.",
-                "video": "https://www.youtube.com/watch?v=-t7fuZ0KhDA",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Pêndulo com peso (3x20s)",
-                "subgrupo": "reabilitação",
-                "equipamentos": ["halteres"],
-                "objetivo": ["mobilidade"],
-                "peso": 1,
-                "descricao": "Incline-se à frente com um halter leve e balance suavemente o braço em círculos pequenos.",
-                "video": "https://www.youtube.com/watch?v=vCE1rYdgK7I",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Press militar (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres", "barra"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Com halteres ou barra à altura dos ombros, empurre o peso para cima até estender completamente os braços.",
-                "video": "https://www.youtube.com/watch?v=qEwKCR5JCog",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Remada face pull com elástico (3x12)",
-                "subgrupo": "estabilidade",
-                "equipamentos": ["elastico"],
-                "objetivo": ["mobilidade", "postura"],
-                "peso": 2,
-                "descricao": "Puxe o elástico em direção ao rosto com os cotovelos altos, ativando o trapézio e deltoide posterior.",
-                "video": "https://www.youtube.com/watch?v=rep-qVOkqgk",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Isometria escapular na parede (2x45s)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["mobilidade"],
-                "peso": 2,
-                "descricao": "Encoste as costas na parede e pressione as escápulas contra ela, mantendo por 45 segundos.",
-                "video": "https://www.youtube.com/watch?v=bd3di7zq-6k",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Serrátil ativação + push-up (3x10)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["postura", "mobilidade"],
-                "peso": 2,
-                "descricao": "Durante a flexão, ao final do movimento, empurre ainda mais o chão, ativando o serrátil.",
-                "video": "https://www.youtube.com/watch?v=R4h7uYgU0YQ",
-                "exclusivoAcademia": false
-            }
-        ]
-        ,
-        "core": [
-            {
-                "nome": "Prancha frontal (3x30s)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["core", "jiujitsu"],
-                "peso": 2,
-                "descricao": "Fique apoiado nos antebraços e nas pontas dos pés, mantendo o corpo reto e contraindo o abdômen.",
-                "video": "https://www.youtube.com/watch?v=pSHjTRCQxIw",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Canivete (3x15)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["core"],
-                "peso": 3,
-                "descricao": "Deite-se e eleve simultaneamente pernas e tronco, tentando tocar os pés com as mãos.",
-                "video": "https://www.youtube.com/watch?v=pqgcEIaXGfs",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Abdominal inclinado (3x20)",
-                "subgrupo": "forca",
-                "equipamentos": ["banco"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Use um banco inclinado e realize o abdominal com maior amplitude e carga no core.",
-                "video": "https://www.youtube.com/watch?v=1fbU_MkV7NE",
-                "exclusivoAcademia": true
-            },
-            {
-                "nome": "Prancha com elevação de pernas (3x30s)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["core", "equilibrio"],
-                "peso": 3,
-                "descricao": "Na posição de prancha, eleve uma perna de cada vez mantendo a estabilidade do tronco.",
-                "video": "https://www.youtube.com/watch?v=ASdvN_XEl_c",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Dead Bug com halteres (3x10)",
-                "subgrupo": "estabilidade",
-                "equipamentos": ["halteres"],
-                "objetivo": ["core", "coordenação"],
-                "peso": 3,
-                "descricao": "Deitado de costas, mova pernas e braços opostos mantendo o core estabilizado.",
-                "video": "https://www.youtube.com/watch?v=8fDVhYJqX8E",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Russian Twist (3x20)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["core"],
-                "peso": 2,
-                "descricao": "Sentado, com os pés suspensos, gire o tronco de um lado para o outro com controle.",
-                "video": "https://www.youtube.com/watch?v=wkD8rjkodUI",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Prancha lateral (3x30s cada lado)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["core", "equilibrio"],
-                "peso": 2,
-                "descricao": "Apoie-se sobre um antebraço e a lateral do pé, mantendo o corpo reto.",
-                "video": "https://www.youtube.com/watch?v=K2VljzCC16g",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Abdominal V (3x15)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["core", "equilibrio"],
-                "peso": 3,
-                "descricao": "Eleve simultaneamente tronco e pernas em forma de 'V', sem encostar no chão entre as repetições.",
-                "video": "https://www.youtube.com/watch?v=QfZbYhP72AU",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Abdominal na barra (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["barra"],
-                "objetivo": ["core", "explosao"],
-                "peso": 4,
-                "descricao": "Pendure-se na barra e eleve os joelhos ou as pernas até o peito ou acima.",
-                "video": "https://www.youtube.com/watch?v=SQBQNhk_x0g",
-                "exclusivoAcademia": true
-            },
-            {
-                "nome": "Hollow Body Hold (3x30s)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["core", "jiujitsu"],
-                "peso": 3,
-                "descricao": "Deitado, mantenha tronco e pernas elevadas com o abdômen totalmente contraído.",
-                "video": "https://www.youtube.com/watch?v=ZJ8Zdj0OPMI",
-                "exclusivoAcademia": false
-            }
-        ]
-        ,
-        "pernas": [
-            {
-                "nome": "Agachamento com halteres (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca", "resistencia"],
-                "peso": 3,
-                "descricao": "Com um halter em cada mão, agache mantendo a coluna reta e os joelhos alinhados com os pés.",
-                "video": "https://www.youtube.com/watch?v=t3HGh8W19c0",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Passada com tornozeleira (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["tornozeleira"],
-                "objetivo": ["forca", "mobilidade"],
-                "peso": 3,
-                "descricao": "Dê um passo à frente com uma perna e agache mantendo o tronco reto, depois retorne e troque o lado.",
-                "video": "https://www.youtube.com/watch?v=xP1oM8ydOxA",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Adutor com elástico (2x15)",
-                "subgrupo": "isolamento",
-                "equipamentos": ["elastico"],
-                "objetivo": ["estabilidade"],
-                "peso": 2,
-                "descricao": "Com o elástico preso nas pernas, aproxime uma da outra, ativando a musculatura interna da coxa.",
-                "video": "https://www.youtube.com/watch?v=GZRIxtTRz18",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Avanço frontal com peso (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Com halteres ao lado do corpo, dê um passo à frente, agache e volte à posição inicial.",
-                "video": "https://www.youtube.com/watch?v=QF0BQS2W80k",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Pistol squat assistido (3x8)",
-                "subgrupo": "controle",
-                "equipamentos": [],
-                "objetivo": ["mobilidade", "controle motor"],
-                "peso": 4,
-                "descricao": "Com apoio numa parede ou objeto fixo, agache com uma perna estendida à frente, controlando a descida.",
-                "video": "https://www.youtube.com/watch?v=1xMaFs0L3ao",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Elevação de panturrilha (3x20)",
-                "subgrupo": "isolamento",
-                "equipamentos": [],
-                "objetivo": ["resistencia"],
-                "peso": 2,
-                "descricao": "Fique em pé e levante os calcanhares do chão, contraindo as panturrilhas, e depois desça devagar.",
-                "video": "https://www.youtube.com/watch?v=-M4-G8p8fmc",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Sumô deadlift (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres", "barra"],
-                "objetivo": ["forca", "adutores"],
-                "peso": 4,
-                "descricao": "Com pés afastados e pontas para fora, segure o peso entre as pernas e levante mantendo a coluna neutra.",
-                "video": "https://www.youtube.com/watch?v=sd6xLDBK6zY",
-                "exclusivoAcademia": false
-            },
-
-            {
-                "nome": "Agachamento búlgaro (3x10 por perna)",
-                "subgrupo": "forca",
-                "equipamentos": ["banco"],
-                "objetivo": ["forca", "equilibrio"],
-                "peso": 4,
-                "descricao": "Fique em pé com um pé apoiado atrás em um banco. Com o tronco reto, agache com a perna da frente até o joelho formar um ângulo de 90°. Volte à posição inicial e repita.",
-                "video": "https://www.youtube.com/watch?v=uh1xK1oInJ4",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Agachamento com salto (3x12)",
-                "subgrupo": "explosao",
-                "equipamentos": [],
-                "objetivo": ["potencia", "resistencia"],
-                "peso": 3,
-                "descricao": "Faça um agachamento comum e, ao subir, dê um salto explosivo. Aterre suavemente e já desça para a próxima repetição.",
-                "video": "https://www.youtube.com/watch?v=tlI0U5gFGWc",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Step-up com halteres (3x10 por perna)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres", "banco"],
-                "objetivo": ["forca", "estabilidade"],
-                "peso": 3,
-                "descricao": "Com um halter em cada mão, suba com uma perna sobre um banco. Empurre o corpo para cima até estender o joelho e volte controlando o movimento.",
-                "video": "https://www.youtube.com/watch?v=QAFD9lJe4iw",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Agachamento sumô (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca", "adutores"],
-                "peso": 3,
-                "descricao": "Afaste bem os pés, com as pontas levemente voltadas para fora. Segure o halter com os braços estendidos e agache mantendo as costas retas até os joelhos ficarem paralelos ao chão.",
-                "video": "https://www.youtube.com/watch?v=8jHXu86O01w",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Elevação de panturrilha unilateral (3x15 por perna)",
-                "subgrupo": "resistencia",
-                "equipamentos": [],
-                "objetivo": ["resistencia", "equilibrio"],
-                "peso": 2,
-                "descricao": "Fique de pé com uma perna só e eleve o calcanhar o máximo possível, contraindo a panturrilha. Desça lentamente e repita. Apoie-se levemente em uma parede se precisar.",
-                "video": "https://www.youtube.com/watch?v=YMmgqO8Jo-k",
-                "exclusivoAcademia": false
-            }
-        ]
-        ,
-        "fullbody": [
-            {
-                "nome": "Burpee + saco de pancada (4x30s)",
-                "subgrupo": "resistencia",
-                "equipamentos": ["saco"],
-                "objetivo": ["condicionamento"],
-                "peso": 4,
-                "descricao": "Faça um burpee completo e, ao levantar, realize uma sequência de socos no saco de pancada.",
-                "video": "https://www.youtube.com/watch?v=zzDbKWHkY5M",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Jumping Jack + prancha (3x45s)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["condicionamento", "core"],
-                "peso": 3,
-                "descricao": "Execute jumping jacks por alguns segundos e em seguida assuma a posição de prancha. Alterne.",
-                "video": "https://www.youtube.com/watch?v=Q2bw_lh4wYI",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Circuito livre funcional (5 min)",
-                "subgrupo": "misturado",
-                "equipamentos": [],
-                "objetivo": ["resistencia", "agilidade"],
-                "peso": 3,
-                "descricao": "Escolha 3 a 5 exercícios funcionais e realize de forma contínua, sem descanso, por 5 minutos.",
-                "video": "https://www.youtube.com/watch?v=6t63UJ_Iav4",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Deslocamento com socos no saco (4x1min)",
-                "subgrupo": "agilidade",
-                "equipamentos": ["saco"],
-                "objetivo": ["coordenação", "agilidade"],
-                "peso": 3,
-                "descricao": "Desloque-se lateralmente e, ao parar, realize sequência de socos rápidos no saco de pancada.",
-                "video": "https://www.youtube.com/watch?v=9sW-H4cO4Do",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Agachamento + puxada elástica (3x12)",
-                "subgrupo": "combinado",
-                "equipamentos": ["elastico"],
-                "objetivo": ["forca", "core"],
-                "peso": 3,
-                "descricao": "Agache com o elástico preso à frente e, ao subir, faça uma puxada como se fosse um 'remo em pé'.",
-                "video": "https://www.youtube.com/watch?v=jKx8ki3zR_c",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Push-up + remo com halteres (3x10)",
-                "subgrupo": "combinado",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca", "core"],
-                "peso": 4,
-                "descricao": "Faça uma flexão de braço e, na subida, reme um dos halteres puxando em direção à cintura. Alterne os lados.",
-                "video": "https://www.youtube.com/watch?v=roCP6wCXPqo",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Bear crawl + parada isométrica (4x10m)",
-                "subgrupo": "controle",
-                "equipamentos": [],
-                "objetivo": ["core", "mobilidade"],
-                "peso": 3,
-                "descricao": "Engatinhe com o quadril baixo (bear crawl) por 10 metros e finalize com isometria na posição por alguns segundos.",
-                "video": "https://www.youtube.com/watch?v=Rcuh_0ySw60",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Mountain Climbers (4x30s)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["condicionamento", "core"],
-                "peso": 3,
-                "descricao": "Na posição de prancha, alterne rapidamente os joelhos em direção ao peito, mantendo o tronco firme.",
-                "video": "https://www.youtube.com/watch?v=nmwgirgXLYM",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Sprawl explosivo (3x12)",
-                "subgrupo": "defensivo",
-                "equipamentos": [],
-                "objetivo": ["defesa", "explosão", "jiujitsu"],
-                "peso": 4,
-                "descricao": "Simule uma defesa de queda: jogue os pés para trás como um burpee e volte rapidamente à base.",
-                "video": "https://www.youtube.com/watch?v=SmJHhBUp6lA",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Pulo no banco com agachamento (3x10)",
-                "subgrupo": "explosao",
-                "equipamentos": ["banco"],
-                "objetivo": ["explosão", "resistencia"],
-                "peso": 4,
-                "descricao": "Suba em um banco ou degrau com salto, desça com controle e realize um agachamento completo.",
-                "video": "https://www.youtube.com/watch?v=wKg05xHHJxw",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Turkish Get-Up (2x5 cada lado)",
-                "subgrupo": "controle",
-                "equipamentos": ["halteres", "kettlebell"],
-                "objetivo": ["core", "mobilidade", "coordenação"],
-                "peso": 4,
-                "descricao": "Levante-se do chão até a posição em pé mantendo o peso sobre a cabeça com o braço estendido.",
-                "video": "https://www.youtube.com/watch?v=u3gQT2aEaUg",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Slam com saco (3x15)",
-                "subgrupo": "explosao",
-                "equipamentos": ["saco"],
-                "objetivo": ["forca", "condicionamento"],
-                "peso": 4,
-                "descricao": "Erga o saco acima da cabeça e jogue-o no chão com força, usando o corpo todo. Repita com ritmo.",
-                "video": "https://www.youtube.com/watch?v=rjWJrT_ZpVE",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Crawl lateral com elástico (4x8m)",
-                "subgrupo": "controle",
-                "equipamentos": ["elastico"],
-                "objetivo": ["mobilidade", "core", "estabilidade"],
-                "peso": 3,
-                "descricao": "Agache levemente com o elástico nos joelhos e ande lateralmente com controle e cadência.",
-                "video": "https://www.youtube.com/watch?v=UpZDYrs0VHA",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Thruster com halteres (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca", "cardio"],
-                "peso": 4,
-                "descricao": "Agache com os halteres nos ombros e, ao subir, empurre-os para cima em um único movimento explosivo.",
-                "video": "https://www.youtube.com/watch?v=q4ZUlNfKNEw",
-                "exclusivoAcademia": false
-            }
-        ],
-        "cardio": [
-            {
-                "nome": "Corda (3x1min)",
-                "subgrupo": "cardio",
-                "equipamentos": ["corda"],
-                "objetivo": ["condicionamento"],
-                "peso": 3,
-                "descricao": "Pule corda em ritmo constante por 1 minuto. Mantenha os cotovelos junto ao corpo e gire a corda com os punhos.",
-                "video": "https://www.youtube.com/watch?v=1BZM7e8Lyk8",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Corrida no lugar (2x2min)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["resistencia"],
-                "peso": 2,
-                "descricao": "Corra no mesmo lugar elevando levemente os joelhos e movimentando os braços como em uma corrida real.",
-                "video": "https://www.youtube.com/watch?v=W3LTTuPYKxw",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Sacos alternados (3x30s)",
-                "subgrupo": "intensidade",
-                "equipamentos": ["saco"],
-                "objetivo": ["coordenação"],
-                "peso": 3,
-                "descricao": "Alterne socos fortes de direita e esquerda em ritmo rápido no saco de pancada. Mantenha a base firme e o tronco solto.",
-                "video": "https://www.youtube.com/watch?v=nV6g3xUdJVg",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Sprint na praça (5x40m)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["velocidade"],
-                "peso": 3,
-                "descricao": "Corra na máxima velocidade por 40 metros e caminhe de volta para recuperar antes de repetir. Ideal em praças ou campos.",
-                "video": "https://www.youtube.com/watch?v=soxrZlIl35U",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Burpee com salto (3x12)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["condicionamento"],
-                "peso": 4,
-                "descricao": "Agache, leve os pés para trás em prancha, retorne e salte para o alto. Um movimento completo conta como uma repetição.",
-                "video": "https://www.youtube.com/watch?v=TU8QYVW0gDU",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Deslocamento lateral rápido (4x30s)",
-                "subgrupo": "agilidade",
-                "equipamentos": [],
-                "objetivo": ["explosão"],
-                "peso": 3,
-                "descricao": "Mova-se rapidamente de um lado para o outro com passos curtos e rápidos, mantendo o tronco baixo e equilibrado.",
-                "video": "https://www.youtube.com/watch?v=FqSx35wIro4",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Corrida com parada e volta (3x1min)",
-                "subgrupo": "resistencia",
-                "equipamentos": [],
-                "objetivo": ["agilidade"],
-                "peso": 3,
-                "descricao": "Corra até um ponto e volte, repetindo o processo por 1 minuto. Faça paradas bruscas para trabalhar a desaceleração.",
-                "video": "https://www.youtube.com/watch?v=Ar3LV6gUxjM",
-                "exclusivoAcademia": false
-            }
-
-            , {
-                "nome": "High Knees (3x40s)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["condicionamento", "agilidade"],
-                "peso": 3,
-                "descricao": "Corra parado elevando os joelhos o mais alto possível. Mantenha o tronco ereto e use os braços para impulsionar.",
-                "video": "https://www.youtube.com/watch?v=8opcQdC-V-U",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Mountain Climbers (3x40s)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["condicionamento", "core"],
-                "peso": 3,
-                "descricao": "Em posição de prancha, traga os joelhos alternadamente ao peito em ritmo acelerado, como se estivesse correndo no chão.",
-                "video": "https://www.youtube.com/watch?v=nmwgirgXLYM",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Polichinelo com chute frontal (3x30s)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["coordenação", "condicionamento"],
-                "peso": 2,
-                "descricao": "Faça um polichinelo e, ao fechar os pés, execute um chute frontal alternado. Mantenha ritmo constante.",
-                "video": "https://www.youtube.com/watch?v=s0nT_fHj4yQ",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Shadow boxing (4x1min)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["coordenação", "agilidade"],
-                "peso": 2,
-                "descricao": "Simule golpes no ar como em uma luta de boxe, movimentando o corpo o tempo todo. Foque em velocidade e fluidez.",
-                "video": "https://www.youtube.com/watch?v=WuqzXN0SnYI",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Corrida em zig-zag (5x30s)",
-                "subgrupo": "agilidade",
-                "equipamentos": [],
-                "objetivo": ["explosão", "resposta motora"],
-                "peso": 3,
-                "descricao": "Marque cones ou objetos no chão e corra em zigue-zague entre eles o mais rápido que puder. Use espaços como corredores ou garagens.",
-                "video": "https://www.youtube.com/watch?v=35FWZ_eiMEg",
-                "exclusivoAcademia": false
-            }
-        ],
-        "joelho": [
-            {
-                "nome": "Agachamento isométrico (3x30s)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["estabilidade"],
-                "peso": 2,
-                "descricao": "Encoste as costas em uma parede e deslize até que os joelhos fiquem em 90°. Mantenha a posição por 30 segundos.",
-                "video": "https://www.youtube.com/watch?v=CtQzJrM3j5g",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Ponte unilateral (2x12)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["controle motor"],
-                "peso": 2,
-                "descricao": "Deite-se de costas, um pé apoiado e o outro elevado. Eleve o quadril mantendo o tronco firme e retorne.",
-                "video": "https://www.youtube.com/watch?v=fO3h_jkPWeY",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Extensão com peso (2x15)",
-                "subgrupo": "isolamento",
-                "equipamentos": ["halteres"],
-                "objetivo": ["reabilitação"],
-                "peso": 2,
-                "descricao": "Sentado, com o peso preso no tornozelo, estenda lentamente a perna até quase a horizontal e volte.",
-                "video": "https://www.youtube.com/watch?v=fFTgEwjJntc",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Agachamento com apoio (3x15)",
-                "subgrupo": "reabilitação",
-                "equipamentos": [],
-                "objetivo": ["estabilidade"],
-                "peso": 2,
-                "descricao": "Segure-se em uma cadeira ou barra e realize agachamentos controlados, sem passar dos 90° de flexão.",
-                "video": "https://www.youtube.com/watch?v=TuEb43H1y1c",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Descida unilateral controlada (3x10)",
-                "subgrupo": "controle",
-                "equipamentos": [],
-                "objetivo": ["reabilitação", "equilibrio"],
-                "peso": 3,
-                "descricao": "Em pé sobre uma perna, realize uma descida lenta até tocar o solo com o calcanhar oposto e volte à posição inicial.",
-                "video": "https://www.youtube.com/watch?v=yhCwFKXwjlA",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Avanço isométrico (3x30s)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["controle"],
-                "peso": 2,
-                "descricao": "Mantenha a posição de avanço (lunge) com os joelhos a 90°, firme e estável por 30 segundos em cada perna.",
-                "video": "https://www.youtube.com/watch?v=qBLf-yIQvvI",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Step up na praça (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["banco"],
-                "objetivo": ["forca", "estabilidade"],
-                "peso": 3,
-                "descricao": "Suba com uma perna sobre um banco ou degrau e traga a outra, depois retorne com controle.",
-                "video": "https://www.youtube.com/watch?v=xM8bB1qLOuY",
-                "exclusivoAcademia": false
-            }
-        ],
-        "dedos": [
-            {
-                "nome": "Pinça manual (2x20s)",
-                "subgrupo": "pegada",
-                "equipamentos": ["pinça"],
-                "objetivo": ["pegada"],
-                "peso": 2,
-                "descricao": "Segure a pinça com força entre os dedos polegar e indicador por 20 segundos, focando na contração da pegada.",
-                "video": "https://www.youtube.com/watch?v=7a0LrZKzR1M",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Elástico de dedos (3x15)",
-                "subgrupo": "pegada",
-                "equipamentos": ["elastico"],
-                "objetivo": ["mobilidade", "pegada"],
-                "peso": 1,
-                "descricao": "Coloque um elástico ao redor dos dedos e afaste-os o máximo possível. Retorne devagar e repita.",
-                "video": "https://www.youtube.com/watch?v=bzxgoJ3LgIM",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Pegador de mão (até falha x2)",
-                "subgrupo": "forca",
-                "equipamentos": ["pegador"],
-                "objetivo": ["pegada"],
-                "peso": 3,
-                "descricao": "Feche o pegador de mão com força até a falha muscular. Faça duas séries com cada mão.",
-                "video": "https://www.youtube.com/watch?v=yi82tAt2MPY",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Torção de toalha molhada (3x30s)",
-                "subgrupo": "resistencia",
-                "equipamentos": ["toalha"],
-                "objetivo": ["pegada", "resistencia"],
-                "peso": 2,
-                "descricao": "Com uma toalha molhada, faça movimentos de torção como se estivesse espremendo. Troque a direção a cada série.",
-                "video": "https://www.youtube.com/watch?v=5DwAkSy5eRQ",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Isometria de pegada com elástico (3x30s)",
-                "subgrupo": "pegada",
-                "equipamentos": ["elastico"],
-                "objetivo": ["resistencia"],
-                "peso": 2,
-                "descricao": "Segure o elástico em posição de pegada forte por 30 segundos. Mantenha os dedos firmes e os punhos estáveis.",
-                "video": "https://www.youtube.com/watch?v=8PkeUKTfqfw",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Pull-up estático (3x10s)",
-                "subgrupo": "pegada",
-                "equipamentos": ["barra"],
-                "objetivo": ["forca", "resistencia"],
-                "peso": 3,
-                "descricao": "Segure-se na barra com os braços flexionados e mantenha o corpo suspenso por 10 segundos.",
-                "video": "https://www.youtube.com/watch?v=_xDczRjPrcA",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Pegada no pano de kimono (3x20s)",
-                "subgrupo": "jiujitsu",
-                "equipamentos": ["kimono"],
-                "objetivo": ["realismo", "pegada"],
-                "peso": 2,
-                "descricao": "Segure o pano do kimono firmemente com ambas as mãos e mantenha a contração por 20 segundos.",
-                "video": "https://www.youtube.com/watch?v=yKqYi8BbJxY",
-                "exclusivoAcademia": false
-            }
-        ],
-        "peito": [
-            {
-                "nome": "Flexão de braços (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Realize flexões mantendo o corpo alinhado e descendo até próximo ao chão.",
-                "video": "https://www.youtube.com/watch?v=IODxDxX7oi4",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Supino com halteres (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Deite-se em um banco e empurre os halteres para cima até estender os braços.",
-                "video": "https://www.youtube.com/watch?v=1lTaarNqmE4",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Crucifixo com halteres (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca", "mobilidade"],
-                "peso": 3,
-                "descricao": "Com os braços semiflexionados, abra-os lateralmente até o nível do peito e retorne.",
-                "video": "https://www.youtube.com/watch?v=eozdVDA78K0",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Flexão de braços na parede (3x15)",
-                "subgrupo": "forca",
-                "equipamentos": [],
-                "objetivo": ["forca"],
-                "peso": 1,
-                "descricao": "Apoie as mãos na parede e realize a flexão mantendo o corpo alinhado, ideal para iniciantes.",
-                "video": "https://www.youtube.com/watch?v=VVEbD8ReG5s",
-                "exclusivoAcademia": false
-            }
-        ],
-        "costas": [
-            {
-                "nome": "Remada curvada com halteres (3x10)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Com tronco inclinado, puxe os halteres em direção ao abdômen.",
-                "video": "https://www.youtube.com/watch?v=vT2GjY_Umpw",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Barra fixa (3x8)",
-                "subgrupo": "forca",
-                "equipamentos": ["barra"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Segure a barra com as palmas voltadas para frente e eleve o corpo até o queixo ultrapassar a barra.",
-                "video": "https://www.youtube.com/watch?v=eGo4IYlbE5g",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Superman (3x15)",
-                "subgrupo": "estabilidade",
-                "equipamentos": [],
-                "objetivo": ["estabilidade", "jiujitsu"],
-                "peso": 2,
-                "descricao": "Deitado de barriga para baixo, eleve simultaneamente braços e pernas, mantendo alguns segundos no ar.",
-                "video": "https://www.youtube.com/watch?v=z6PJMT2y8GQ",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Remada com elástico sentado (3x15)",
-                "subgrupo": "forca",
-                "equipamentos": ["elastico"],
-                "objetivo": ["forca"],
-                "peso": 2,
-                "descricao": "Sente-se com as pernas estendidas, prenda o elástico nos pés e puxe as extremidades em direção ao tronco.",
-                "video": "https://www.youtube.com/watch?v=LyRA47PlP-A",
-                "exclusivoAcademia": false
-            }
-        ],
-        "bracos": [
-            {
-                "nome": "Rosca direta com halteres (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["halteres"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Em pé, flexione os cotovelos levantando os halteres até a altura dos ombros.",
-                "video": "https://www.youtube.com/watch?v=ykJmrZ5v0Oo",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Tríceps mergulho (3x12)",
-                "subgrupo": "forca",
-                "equipamentos": ["banco"],
-                "objetivo": ["forca"],
-                "peso": 3,
-                "descricao": "Apoie as mãos atrás do corpo em um banco e desça o tronco flexionando os cotovelos.",
-                "video": "https://www.youtube.com/watch?v=0326dy_-CzM",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Extensão de tríceps com elástico (3x15)",
-                "subgrupo": "resistencia",
-                "equipamentos": ["elastico"],
-                "objetivo": ["resistencia"],
-                "peso": 2,
-                "descricao": "Prenda o elástico acima da cabeça e estenda os braços para baixo até ficarem alinhados ao corpo.",
-                "video": "https://www.youtube.com/watch?v=6SS6K3lAwZ8",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Rosca com elástico (3x15)",
-                "subgrupo": "resistencia",
-                "equipamentos": ["elastico"],
-                "objetivo": ["resistencia"],
-                "peso": 2,
-                "descricao": "Pise sobre o elástico segurando as pontas e flexione os cotovelos, trazendo as mãos em direção aos ombros.",
-                "video": "https://www.youtube.com/watch?v=MsAN5XgkjnA",
-                "exclusivoAcademia": false
-            }
-        ],
-        "hiit": [
-            {
-                "nome": "Burpee (4x10)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["hiit", "condicionamento"],
-                "peso": 3,
-                "descricao": "Do agachamento à flexão e salto, execute o movimento de forma explosiva.",
-                "video": "https://www.youtube.com/watch?v=TU8QYVW0gDU",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Mountain climbers (4x20)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["hiit", "condicionamento"],
-                "peso": 3,
-                "descricao": "Em posição de prancha, alterne rapidamente os joelhos em direção ao peito.",
-                "video": "https://www.youtube.com/watch?v=nmwgirgXLYM",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Sprint estacionário (6x15s)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["hiit", "condicionamento"],
-                "peso": 3,
-                "descricao": "Corra no lugar na maior velocidade possível por 15 segundos e descanse entre as séries.",
-                "video": "https://www.youtube.com/watch?v=2v0RhvZ3lvY",
-                "exclusivoAcademia": false
-            },
-            {
-                "nome": "Polichinelos (4x30)",
-                "subgrupo": "cardio",
-                "equipamentos": [],
-                "objetivo": ["hiit", "condicionamento"],
-                "peso": 2,
-                "descricao": "Salte abrindo e fechando braços e pernas de forma contínua, mantendo ritmo acelerado.",
-                "video": "https://www.youtube.com/watch?v=c4DAnQ6DtF8",
-                "exclusivoAcademia": false
-            }
-        ]
+  "ombro": [
+    {
+      "nome": "Wall Angels (3x15)",
+      "subgrupo": "mobilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "mobilidade",
+        "jiujitsu"
+      ],
+      "peso": 1,
+      "descricao": "Fique encostado na parede, com braços dobrados a 90°, deslize-os para cima e para baixo sem tirar as costas da parede.",
+      "video": "https://www.youtube.com/watch?v=Im3DTNGjMJo",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Shrug com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Segure os halteres ao lado do corpo e eleve os ombros como se estivesse tentando tocar as orelhas.",
+      "video": "https://www.youtube.com/watch?v=pYcpY20QaE8",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Elevação lateral (2x15)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca",
+        "mobilidade"
+      ],
+      "peso": 3,
+      "descricao": "Com halteres nas mãos, levante os braços lateralmente até a altura dos ombros e volte lentamente.",
+      "video": "https://www.youtube.com/watch?v=3VcKaXpzqRo",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Rotação externa com elástico (3x15)",
+      "subgrupo": "reabilitação",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "mobilidade"
+      ],
+      "peso": 1,
+      "descricao": "Com o braço colado ao corpo, gire o antebraço para fora contra a resistência do elástico.",
+      "video": "https://www.youtube.com/watch?v=BYNR86w3Ww8",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Frontal raise com halteres (2x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Erga os halteres à frente do corpo até a altura dos ombros, mantendo os braços estendidos.",
+      "video": "https://www.youtube.com/watch?v=-t7fuZ0KhDA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Pêndulo com peso (3x20s)",
+      "subgrupo": "reabilitação",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "mobilidade"
+      ],
+      "peso": 1,
+      "descricao": "Incline-se à frente com um halter leve e balance suavemente o braço em círculos pequenos.",
+      "video": "https://www.youtube.com/watch?v=vCE1rYdgK7I",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Press militar (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres",
+        "barra"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Com halteres ou barra à altura dos ombros, empurre o peso para cima até estender completamente os braços.",
+      "video": "https://www.youtube.com/watch?v=qEwKCR5JCog",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Remada face pull com elástico (3x12)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "mobilidade",
+        "postura"
+      ],
+      "peso": 2,
+      "descricao": "Puxe o elástico em direção ao rosto com os cotovelos altos, ativando o trapézio e deltoide posterior.",
+      "video": "https://www.youtube.com/watch?v=rep-qVOkqgk",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Isometria escapular na parede (2x45s)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "mobilidade"
+      ],
+      "peso": 2,
+      "descricao": "Encoste as costas na parede e pressione as escápulas contra ela, mantendo por 45 segundos.",
+      "video": "https://www.youtube.com/watch?v=bd3di7zq-6k",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Serrátil ativação + push-up (3x10)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "postura",
+        "mobilidade"
+      ],
+      "peso": 2,
+      "descricao": "Durante a flexão, ao final do movimento, empurre ainda mais o chão, ativando o serrátil.",
+      "video": "https://www.youtube.com/watch?v=R4h7uYgU0YQ",
+      "exclusivoAcademia": false
     }
+  ],
+  "core": [
+    {
+      "nome": "Prancha frontal (3x30s)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "core",
+        "jiujitsu"
+      ],
+      "peso": 2,
+      "descricao": "Fique apoiado nos antebraços e nas pontas dos pés, mantendo o corpo reto e contraindo o abdômen.",
+      "video": "https://www.youtube.com/watch?v=pSHjTRCQxIw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Canivete (3x15)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "core"
+      ],
+      "peso": 3,
+      "descricao": "Deite-se e eleve simultaneamente pernas e tronco, tentando tocar os pés com as mãos.",
+      "video": "https://www.youtube.com/watch?v=pqgcEIaXGfs",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Abdominal inclinado (3x20)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "banco"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Use um banco inclinado e realize o abdominal com maior amplitude e carga no core.",
+      "video": "https://www.youtube.com/watch?v=1fbU_MkV7NE",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Prancha com elevação de pernas (3x30s)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "core",
+        "equilibrio"
+      ],
+      "peso": 3,
+      "descricao": "Na posição de prancha, eleve uma perna de cada vez mantendo a estabilidade do tronco.",
+      "video": "https://www.youtube.com/watch?v=ASdvN_XEl_c",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Dead Bug com halteres (3x10)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "core",
+        "coordenação"
+      ],
+      "peso": 3,
+      "descricao": "Deitado de costas, mova pernas e braços opostos mantendo o core estabilizado.",
+      "video": "https://www.youtube.com/watch?v=8fDVhYJqX8E",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Russian Twist (3x20)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "core"
+      ],
+      "peso": 2,
+      "descricao": "Sentado, com os pés suspensos, gire o tronco de um lado para o outro com controle.",
+      "video": "https://www.youtube.com/watch?v=wkD8rjkodUI",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Prancha lateral (3x30s cada lado)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "core",
+        "equilibrio"
+      ],
+      "peso": 2,
+      "descricao": "Apoie-se sobre um antebraço e a lateral do pé, mantendo o corpo reto.",
+      "video": "https://www.youtube.com/watch?v=K2VljzCC16g",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Abdominal V (3x15)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "core",
+        "equilibrio"
+      ],
+      "peso": 3,
+      "descricao": "Eleve simultaneamente tronco e pernas em forma de 'V', sem encostar no chão entre as repetições.",
+      "video": "https://www.youtube.com/watch?v=QfZbYhP72AU",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Abdominal na barra (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "barra"
+      ],
+      "objetivo": [
+        "core",
+        "explosao"
+      ],
+      "peso": 4,
+      "descricao": "Pendure-se na barra e eleve os joelhos ou as pernas até o peito ou acima.",
+      "video": "https://www.youtube.com/watch?v=SQBQNhk_x0g",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Hollow Body Hold (3x30s)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "core",
+        "jiujitsu"
+      ],
+      "peso": 3,
+      "descricao": "Deitado, mantenha tronco e pernas elevadas com o abdômen totalmente contraído.",
+      "video": "https://www.youtube.com/watch?v=ZJ8Zdj0OPMI",
+      "exclusivoAcademia": false
+    }
+  ],
+  "pernas": [
+    {
+      "nome": "Agachamento com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca",
+        "resistencia"
+      ],
+      "peso": 3,
+      "descricao": "Com um halter em cada mão, agache mantendo a coluna reta e os joelhos alinhados com os pés.",
+      "video": "https://www.youtube.com/watch?v=t3HGh8W19c0",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Passada com tornozeleira (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "tornozeleira"
+      ],
+      "objetivo": [
+        "forca",
+        "mobilidade"
+      ],
+      "peso": 3,
+      "descricao": "Dê um passo à frente com uma perna e agache mantendo o tronco reto, depois retorne e troque o lado.",
+      "video": "https://www.youtube.com/watch?v=xP1oM8ydOxA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Adutor com elástico (2x15)",
+      "subgrupo": "isolamento",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "estabilidade"
+      ],
+      "peso": 2,
+      "descricao": "Com o elástico preso nas pernas, aproxime uma da outra, ativando a musculatura interna da coxa.",
+      "video": "https://www.youtube.com/watch?v=GZRIxtTRz18",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Avanço frontal com peso (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Com halteres ao lado do corpo, dê um passo à frente, agache e volte à posição inicial.",
+      "video": "https://www.youtube.com/watch?v=QF0BQS2W80k",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Pistol squat assistido (3x8)",
+      "subgrupo": "controle",
+      "equipamentos": [],
+      "objetivo": [
+        "mobilidade",
+        "controle motor"
+      ],
+      "peso": 4,
+      "descricao": "Com apoio numa parede ou objeto fixo, agache com uma perna estendida à frente, controlando a descida.",
+      "video": "https://www.youtube.com/watch?v=1xMaFs0L3ao",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Elevação de panturrilha (3x20)",
+      "subgrupo": "isolamento",
+      "equipamentos": [],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Fique em pé e levante os calcanhares do chão, contraindo as panturrilhas, e depois desça devagar.",
+      "video": "https://www.youtube.com/watch?v=-M4-G8p8fmc",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Sumô deadlift (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres",
+        "barra"
+      ],
+      "objetivo": [
+        "forca",
+        "adutores"
+      ],
+      "peso": 4,
+      "descricao": "Com pés afastados e pontas para fora, segure o peso entre as pernas e levante mantendo a coluna neutra.",
+      "video": "https://www.youtube.com/watch?v=sd6xLDBK6zY",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Agachamento búlgaro (3x10 por perna)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "banco"
+      ],
+      "objetivo": [
+        "forca",
+        "equilibrio"
+      ],
+      "peso": 4,
+      "descricao": "Fique em pé com um pé apoiado atrás em um banco. Com o tronco reto, agache com a perna da frente até o joelho formar um ângulo de 90°. Volte à posição inicial e repita.",
+      "video": "https://www.youtube.com/watch?v=uh1xK1oInJ4",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Agachamento com salto (3x12)",
+      "subgrupo": "explosao",
+      "equipamentos": [],
+      "objetivo": [
+        "potencia",
+        "resistencia"
+      ],
+      "peso": 3,
+      "descricao": "Faça um agachamento comum e, ao subir, dê um salto explosivo. Aterre suavemente e já desça para a próxima repetição.",
+      "video": "https://www.youtube.com/watch?v=tlI0U5gFGWc",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Step-up com halteres (3x10 por perna)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres",
+        "banco"
+      ],
+      "objetivo": [
+        "forca",
+        "estabilidade"
+      ],
+      "peso": 3,
+      "descricao": "Com um halter em cada mão, suba com uma perna sobre um banco. Empurre o corpo para cima até estender o joelho e volte controlando o movimento.",
+      "video": "https://www.youtube.com/watch?v=QAFD9lJe4iw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Agachamento sumô (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca",
+        "adutores"
+      ],
+      "peso": 3,
+      "descricao": "Afaste bem os pés, com as pontas levemente voltadas para fora. Segure o halter com os braços estendidos e agache mantendo as costas retas até os joelhos ficarem paralelos ao chão.",
+      "video": "https://www.youtube.com/watch?v=8jHXu86O01w",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Elevação de panturrilha unilateral (3x15 por perna)",
+      "subgrupo": "resistencia",
+      "equipamentos": [],
+      "objetivo": [
+        "resistencia",
+        "equilibrio"
+      ],
+      "peso": 2,
+      "descricao": "Fique de pé com uma perna só e eleve o calcanhar o máximo possível, contraindo a panturrilha. Desça lentamente e repita. Apoie-se levemente em uma parede se precisar.",
+      "video": "https://www.youtube.com/watch?v=YMmgqO8Jo-k",
+      "exclusivoAcademia": false
+    }
+  ],
+  "fullbody": [
+    {
+      "nome": "Burpee + saco de pancada (4x30s)",
+      "subgrupo": "resistencia",
+      "equipamentos": [
+        "saco"
+      ],
+      "objetivo": [
+        "condicionamento"
+      ],
+      "peso": 4,
+      "descricao": "Faça um burpee completo e, ao levantar, realize uma sequência de socos no saco de pancada.",
+      "video": "https://www.youtube.com/watch?v=zzDbKWHkY5M",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Jumping Jack + prancha (3x45s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "condicionamento",
+        "core"
+      ],
+      "peso": 3,
+      "descricao": "Execute jumping jacks por alguns segundos e em seguida assuma a posição de prancha. Alterne.",
+      "video": "https://www.youtube.com/watch?v=Q2bw_lh4wYI",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Circuito livre funcional (5 min)",
+      "subgrupo": "misturado",
+      "equipamentos": [],
+      "objetivo": [
+        "resistencia",
+        "agilidade"
+      ],
+      "peso": 3,
+      "descricao": "Escolha 3 a 5 exercícios funcionais e realize de forma contínua, sem descanso, por 5 minutos.",
+      "video": "https://www.youtube.com/watch?v=6t63UJ_Iav4",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Deslocamento com socos no saco (4x1min)",
+      "subgrupo": "agilidade",
+      "equipamentos": [
+        "saco"
+      ],
+      "objetivo": [
+        "coordenação",
+        "agilidade"
+      ],
+      "peso": 3,
+      "descricao": "Desloque-se lateralmente e, ao parar, realize sequência de socos rápidos no saco de pancada.",
+      "video": "https://www.youtube.com/watch?v=9sW-H4cO4Do",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Agachamento + puxada elástica (3x12)",
+      "subgrupo": "combinado",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "forca",
+        "core"
+      ],
+      "peso": 3,
+      "descricao": "Agache com o elástico preso à frente e, ao subir, faça uma puxada como se fosse um 'remo em pé'.",
+      "video": "https://www.youtube.com/watch?v=jKx8ki3zR_c",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Push-up + remo com halteres (3x10)",
+      "subgrupo": "combinado",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca",
+        "core"
+      ],
+      "peso": 4,
+      "descricao": "Faça uma flexão de braço e, na subida, reme um dos halteres puxando em direção à cintura. Alterne os lados.",
+      "video": "https://www.youtube.com/watch?v=roCP6wCXPqo",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Bear crawl + parada isométrica (4x10m)",
+      "subgrupo": "controle",
+      "equipamentos": [],
+      "objetivo": [
+        "core",
+        "mobilidade"
+      ],
+      "peso": 3,
+      "descricao": "Engatinhe com o quadril baixo (bear crawl) por 10 metros e finalize com isometria na posição por alguns segundos.",
+      "video": "https://www.youtube.com/watch?v=Rcuh_0ySw60",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Mountain Climbers (4x30s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "condicionamento",
+        "core"
+      ],
+      "peso": 3,
+      "descricao": "Na posição de prancha, alterne rapidamente os joelhos em direção ao peito, mantendo o tronco firme.",
+      "video": "https://www.youtube.com/watch?v=nmwgirgXLYM",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Sprawl explosivo (3x12)",
+      "subgrupo": "defensivo",
+      "equipamentos": [],
+      "objetivo": [
+        "defesa",
+        "explosão",
+        "jiujitsu"
+      ],
+      "peso": 4,
+      "descricao": "Simule uma defesa de queda: jogue os pés para trás como um burpee e volte rapidamente à base.",
+      "video": "https://www.youtube.com/watch?v=SmJHhBUp6lA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Pulo no banco com agachamento (3x10)",
+      "subgrupo": "explosao",
+      "equipamentos": [
+        "banco"
+      ],
+      "objetivo": [
+        "explosão",
+        "resistencia"
+      ],
+      "peso": 4,
+      "descricao": "Suba em um banco ou degrau com salto, desça com controle e realize um agachamento completo.",
+      "video": "https://www.youtube.com/watch?v=wKg05xHHJxw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Turkish Get-Up (2x5 cada lado)",
+      "subgrupo": "controle",
+      "equipamentos": [
+        "halteres",
+        "kettlebell"
+      ],
+      "objetivo": [
+        "core",
+        "mobilidade",
+        "coordenação"
+      ],
+      "peso": 4,
+      "descricao": "Levante-se do chão até a posição em pé mantendo o peso sobre a cabeça com o braço estendido.",
+      "video": "https://www.youtube.com/watch?v=u3gQT2aEaUg",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Slam com saco (3x15)",
+      "subgrupo": "explosao",
+      "equipamentos": [
+        "saco"
+      ],
+      "objetivo": [
+        "forca",
+        "condicionamento"
+      ],
+      "peso": 4,
+      "descricao": "Erga o saco acima da cabeça e jogue-o no chão com força, usando o corpo todo. Repita com ritmo.",
+      "video": "https://www.youtube.com/watch?v=rjWJrT_ZpVE",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Crawl lateral com elástico (4x8m)",
+      "subgrupo": "controle",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "mobilidade",
+        "core",
+        "estabilidade"
+      ],
+      "peso": 3,
+      "descricao": "Agache levemente com o elástico nos joelhos e ande lateralmente com controle e cadência.",
+      "video": "https://www.youtube.com/watch?v=UpZDYrs0VHA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Thruster com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca",
+        "cardio"
+      ],
+      "peso": 4,
+      "descricao": "Agache com os halteres nos ombros e, ao subir, empurre-os para cima em um único movimento explosivo.",
+      "video": "https://www.youtube.com/watch?v=q4ZUlNfKNEw",
+      "exclusivoAcademia": false
+    }
+  ],
+  "cardio": [
+    {
+      "nome": "Corda (3x1min)",
+      "subgrupo": "cardio",
+      "equipamentos": [
+        "corda"
+      ],
+      "objetivo": [
+        "condicionamento"
+      ],
+      "peso": 3,
+      "descricao": "Pule corda em ritmo constante por 1 minuto. Mantenha os cotovelos junto ao corpo e gire a corda com os punhos.",
+      "video": "https://www.youtube.com/watch?v=1BZM7e8Lyk8",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Corrida no lugar (2x2min)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Corra no mesmo lugar elevando levemente os joelhos e movimentando os braços como em uma corrida real.",
+      "video": "https://www.youtube.com/watch?v=W3LTTuPYKxw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Sacos alternados (3x30s)",
+      "subgrupo": "intensidade",
+      "equipamentos": [
+        "saco"
+      ],
+      "objetivo": [
+        "coordenação"
+      ],
+      "peso": 3,
+      "descricao": "Alterne socos fortes de direita e esquerda em ritmo rápido no saco de pancada. Mantenha a base firme e o tronco solto.",
+      "video": "https://www.youtube.com/watch?v=nV6g3xUdJVg",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Sprint na praça (5x40m)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "velocidade"
+      ],
+      "peso": 3,
+      "descricao": "Corra na máxima velocidade por 40 metros e caminhe de volta para recuperar antes de repetir. Ideal em praças ou campos.",
+      "video": "https://www.youtube.com/watch?v=soxrZlIl35U",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Burpee com salto (3x12)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "condicionamento"
+      ],
+      "peso": 4,
+      "descricao": "Agache, leve os pés para trás em prancha, retorne e salte para o alto. Um movimento completo conta como uma repetição.",
+      "video": "https://www.youtube.com/watch?v=TU8QYVW0gDU",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Deslocamento lateral rápido (4x30s)",
+      "subgrupo": "agilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "explosão"
+      ],
+      "peso": 3,
+      "descricao": "Mova-se rapidamente de um lado para o outro com passos curtos e rápidos, mantendo o tronco baixo e equilibrado.",
+      "video": "https://www.youtube.com/watch?v=FqSx35wIro4",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Corrida com parada e volta (3x1min)",
+      "subgrupo": "resistencia",
+      "equipamentos": [],
+      "objetivo": [
+        "agilidade"
+      ],
+      "peso": 3,
+      "descricao": "Corra até um ponto e volte, repetindo o processo por 1 minuto. Faça paradas bruscas para trabalhar a desaceleração.",
+      "video": "https://www.youtube.com/watch?v=Ar3LV6gUxjM",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "High Knees (3x40s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "condicionamento",
+        "agilidade"
+      ],
+      "peso": 3,
+      "descricao": "Corra parado elevando os joelhos o mais alto possível. Mantenha o tronco ereto e use os braços para impulsionar.",
+      "video": "https://www.youtube.com/watch?v=8opcQdC-V-U",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Mountain Climbers (3x40s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "condicionamento",
+        "core"
+      ],
+      "peso": 3,
+      "descricao": "Em posição de prancha, traga os joelhos alternadamente ao peito em ritmo acelerado, como se estivesse correndo no chão.",
+      "video": "https://www.youtube.com/watch?v=nmwgirgXLYM",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Polichinelo com chute frontal (3x30s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "coordenação",
+        "condicionamento"
+      ],
+      "peso": 2,
+      "descricao": "Faça um polichinelo e, ao fechar os pés, execute um chute frontal alternado. Mantenha ritmo constante.",
+      "video": "https://www.youtube.com/watch?v=s0nT_fHj4yQ",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Shadow boxing (4x1min)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "coordenação",
+        "agilidade"
+      ],
+      "peso": 2,
+      "descricao": "Simule golpes no ar como em uma luta de boxe, movimentando o corpo o tempo todo. Foque em velocidade e fluidez.",
+      "video": "https://www.youtube.com/watch?v=WuqzXN0SnYI",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Corrida em zig-zag (5x30s)",
+      "subgrupo": "agilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "explosão",
+        "resposta motora"
+      ],
+      "peso": 3,
+      "descricao": "Marque cones ou objetos no chão e corra em zigue-zague entre eles o mais rápido que puder. Use espaços como corredores ou garagens.",
+      "video": "https://www.youtube.com/watch?v=35FWZ_eiMEg",
+      "exclusivoAcademia": false
+    }
+  ],
+  "joelho": [
+    {
+      "nome": "Agachamento isométrico (3x30s)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "estabilidade"
+      ],
+      "peso": 2,
+      "descricao": "Encoste as costas em uma parede e deslize até que os joelhos fiquem em 90°. Mantenha a posição por 30 segundos.",
+      "video": "https://www.youtube.com/watch?v=CtQzJrM3j5g",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Ponte unilateral (2x12)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "controle motor"
+      ],
+      "peso": 2,
+      "descricao": "Deite-se de costas, um pé apoiado e o outro elevado. Eleve o quadril mantendo o tronco firme e retorne.",
+      "video": "https://www.youtube.com/watch?v=fO3h_jkPWeY",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Extensão com peso (2x15)",
+      "subgrupo": "isolamento",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "reabilitação"
+      ],
+      "peso": 2,
+      "descricao": "Sentado, com o peso preso no tornozelo, estenda lentamente a perna até quase a horizontal e volte.",
+      "video": "https://www.youtube.com/watch?v=fFTgEwjJntc",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Agachamento com apoio (3x15)",
+      "subgrupo": "reabilitação",
+      "equipamentos": [],
+      "objetivo": [
+        "estabilidade"
+      ],
+      "peso": 2,
+      "descricao": "Segure-se em uma cadeira ou barra e realize agachamentos controlados, sem passar dos 90° de flexão.",
+      "video": "https://www.youtube.com/watch?v=TuEb43H1y1c",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Descida unilateral controlada (3x10)",
+      "subgrupo": "controle",
+      "equipamentos": [],
+      "objetivo": [
+        "reabilitação",
+        "equilibrio"
+      ],
+      "peso": 3,
+      "descricao": "Em pé sobre uma perna, realize uma descida lenta até tocar o solo com o calcanhar oposto e volte à posição inicial.",
+      "video": "https://www.youtube.com/watch?v=yhCwFKXwjlA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Avanço isométrico (3x30s)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "controle"
+      ],
+      "peso": 2,
+      "descricao": "Mantenha a posição de avanço (lunge) com os joelhos a 90°, firme e estável por 30 segundos em cada perna.",
+      "video": "https://www.youtube.com/watch?v=qBLf-yIQvvI",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Step up na praça (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "banco"
+      ],
+      "objetivo": [
+        "forca",
+        "estabilidade"
+      ],
+      "peso": 3,
+      "descricao": "Suba com uma perna sobre um banco ou degrau e traga a outra, depois retorne com controle.",
+      "video": "https://www.youtube.com/watch?v=xM8bB1qLOuY",
+      "exclusivoAcademia": false
+    }
+  ],
+  "dedos": [
+    {
+      "nome": "Pinça manual (2x20s)",
+      "subgrupo": "pegada",
+      "equipamentos": [
+        "pinça"
+      ],
+      "objetivo": [
+        "pegada"
+      ],
+      "peso": 2,
+      "descricao": "Segure a pinça com força entre os dedos polegar e indicador por 20 segundos, focando na contração da pegada.",
+      "video": "https://www.youtube.com/watch?v=7a0LrZKzR1M",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Elástico de dedos (3x15)",
+      "subgrupo": "pegada",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "mobilidade",
+        "pegada"
+      ],
+      "peso": 1,
+      "descricao": "Coloque um elástico ao redor dos dedos e afaste-os o máximo possível. Retorne devagar e repita.",
+      "video": "https://www.youtube.com/watch?v=bzxgoJ3LgIM",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Pegador de mão (até falha x2)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "pegador"
+      ],
+      "objetivo": [
+        "pegada"
+      ],
+      "peso": 3,
+      "descricao": "Feche o pegador de mão com força até a falha muscular. Faça duas séries com cada mão.",
+      "video": "https://www.youtube.com/watch?v=yi82tAt2MPY",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Torção de toalha molhada (3x30s)",
+      "subgrupo": "resistencia",
+      "equipamentos": [
+        "toalha"
+      ],
+      "objetivo": [
+        "pegada",
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Com uma toalha molhada, faça movimentos de torção como se estivesse espremendo. Troque a direção a cada série.",
+      "video": "https://www.youtube.com/watch?v=5DwAkSy5eRQ",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Isometria de pegada com elástico (3x30s)",
+      "subgrupo": "pegada",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Segure o elástico em posição de pegada forte por 30 segundos. Mantenha os dedos firmes e os punhos estáveis.",
+      "video": "https://www.youtube.com/watch?v=8PkeUKTfqfw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Pull-up estático (3x10s)",
+      "subgrupo": "pegada",
+      "equipamentos": [
+        "barra"
+      ],
+      "objetivo": [
+        "forca",
+        "resistencia"
+      ],
+      "peso": 3,
+      "descricao": "Segure-se na barra com os braços flexionados e mantenha o corpo suspenso por 10 segundos.",
+      "video": "https://www.youtube.com/watch?v=_xDczRjPrcA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Pegada no pano de kimono (3x20s)",
+      "subgrupo": "jiujitsu",
+      "equipamentos": [
+        "kimono"
+      ],
+      "objetivo": [
+        "realismo",
+        "pegada"
+      ],
+      "peso": 2,
+      "descricao": "Segure o pano do kimono firmemente com ambas as mãos e mantenha a contração por 20 segundos.",
+      "video": "https://www.youtube.com/watch?v=yKqYi8BbJxY",
+      "exclusivoAcademia": false
+    }
+  ],
+  "peito": [
+    {
+      "nome": "Flexão de braços (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Realize flexões mantendo o corpo alinhado e descendo até próximo ao chão.",
+      "video": "https://www.youtube.com/watch?v=IODxDxX7oi4",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Supino com halteres (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Deite-se em um banco e empurre os halteres para cima até estender os braços.",
+      "video": "https://www.youtube.com/watch?v=1lTaarNqmE4",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Crucifixo com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca",
+        "mobilidade"
+      ],
+      "peso": 3,
+      "descricao": "Com os braços semiflexionados, abra-os lateralmente até o nível do peito e retorne.",
+      "video": "https://www.youtube.com/watch?v=eozdVDA78K0",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Flexão de braços na parede (3x15)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 1,
+      "descricao": "Apoie as mãos na parede e realize a flexão mantendo o corpo alinhado, ideal para iniciantes.",
+      "video": "https://www.youtube.com/watch?v=VVEbD8ReG5s",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Flexão diamante (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Com as mãos próximas formando um triângulo, desça o corpo mantendo os cotovelos junto ao tronco.",
+      "video": "https://www.youtube.com/watch?v=J0DnG1_S92I",
+      "exclusivoAcademia": false
+    }
+  ],
+  "costas": [
+    {
+      "nome": "Remada curvada com halteres (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Com tronco inclinado, puxe os halteres em direção ao abdômen.",
+      "video": "https://www.youtube.com/watch?v=vT2GjY_Umpw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Barra fixa (3x8)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "barra"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Segure a barra com as palmas voltadas para frente e eleve o corpo até o queixo ultrapassar a barra.",
+      "video": "https://www.youtube.com/watch?v=eGo4IYlbE5g",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Superman (3x15)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [],
+      "objetivo": [
+        "estabilidade",
+        "jiujitsu"
+      ],
+      "peso": 2,
+      "descricao": "Deitado de barriga para baixo, eleve simultaneamente braços e pernas, mantendo alguns segundos no ar.",
+      "video": "https://www.youtube.com/watch?v=z6PJMT2y8GQ",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Remada com elástico sentado (3x15)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 2,
+      "descricao": "Sente-se com as pernas estendidas, prenda o elástico nos pés e puxe as extremidades em direção ao tronco.",
+      "video": "https://www.youtube.com/watch?v=LyRA47PlP-A",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Remada unilateral com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Apoie uma mão e um joelho em um banco e puxe o halter ao lado do tronco.",
+      "video": "https://www.youtube.com/watch?v=8OO4sJ9Ek98",
+      "exclusivoAcademia": false
+    }
+  ],
+  "hiit": [
+    {
+      "nome": "Burpee (4x10)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "hiit",
+        "condicionamento"
+      ],
+      "peso": 3,
+      "descricao": "Do agachamento à flexão e salto, execute o movimento de forma explosiva.",
+      "video": "https://www.youtube.com/watch?v=TU8QYVW0gDU",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Mountain climbers (4x20)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "hiit",
+        "condicionamento"
+      ],
+      "peso": 3,
+      "descricao": "Em posição de prancha, alterne rapidamente os joelhos em direção ao peito.",
+      "video": "https://www.youtube.com/watch?v=nmwgirgXLYM",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Sprint estacionário (6x15s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "hiit",
+        "condicionamento"
+      ],
+      "peso": 3,
+      "descricao": "Corra no lugar na maior velocidade possível por 15 segundos e descanse entre as séries.",
+      "video": "https://www.youtube.com/watch?v=2v0RhvZ3lvY",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Polichinelos (4x30)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "hiit",
+        "condicionamento"
+      ],
+      "peso": 2,
+      "descricao": "Salte abrindo e fechando braços e pernas de forma contínua, mantendo ritmo acelerado.",
+      "video": "https://www.youtube.com/watch?v=c4DAnQ6DtF8",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "High knees (4x30s)",
+      "subgrupo": "cardio",
+      "equipamentos": [],
+      "objetivo": [
+        "hiit",
+        "condicionamento"
+      ],
+      "peso": 3,
+      "descricao": "Corra no lugar elevando os joelhos alternadamente na altura do quadril.",
+      "video": "https://www.youtube.com/watch?v=8BcPHWGQO44",
+      "exclusivoAcademia": false
+    }
+  ],
+  "biceps": [
+    {
+      "nome": "Rosca direta com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Em pé, flexione os cotovelos levantando os halteres até a altura dos ombros.",
+      "video": "https://www.youtube.com/watch?v=ykJmrZ5v0Oo",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Rosca com elástico (3x15)",
+      "subgrupo": "resistencia",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Pise sobre o elástico segurando as pontas e flexione os cotovelos, trazendo as mãos em direção aos ombros.",
+      "video": "https://www.youtube.com/watch?v=MsAN5XgkjnA",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Rosca martelo com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Segure os halteres com pegada neutra e flexione os cotovelos mantendo as palmas voltadas uma para a outra.",
+      "video": "https://www.youtube.com/watch?v=TwD-YGVP4Bk",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Rosca concentrada (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Sentado, apoie o cotovelo na coxa e flexione o halter até o ombro.",
+      "video": "https://www.youtube.com/watch?v=soxrZlIl35U",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Barra fixa pegada supinada (3x8)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "barra"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Com as palmas voltadas para você, puxe o corpo até o queixo ultrapassar a barra.",
+      "video": "https://www.youtube.com/watch?v=CNaC3NzOoZk",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Curl com barra (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "barra"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Em pé, segure a barra com as palmas para cima e flexione os cotovelos até a altura dos ombros.",
+      "video": "https://www.youtube.com/watch?v=kwG2ipFRgfo",
+      "exclusivoAcademia": false
+    }
+  ],
+  "triceps": [
+    {
+      "nome": "Tríceps mergulho (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "banco"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Apoie as mãos atrás do corpo em um banco e desça o tronco flexionando os cotovelos.",
+      "video": "https://www.youtube.com/watch?v=0326dy_-CzM",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Extensão de tríceps com elástico (3x15)",
+      "subgrupo": "resistencia",
+      "equipamentos": [
+        "elastico"
+      ],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Prenda o elástico acima da cabeça e estenda os braços para baixo até ficarem alinhados ao corpo.",
+      "video": "https://www.youtube.com/watch?v=6SS6K3lAwZ8",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Tríceps testa com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Deitado, flexione e estenda os cotovelos levando os halteres em direção à testa.",
+      "video": "https://www.youtube.com/watch?v=ir5PsbniVSc",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Tríceps francês com halteres (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Eleve o halter acima da cabeça e flexione os cotovelos levando o peso atrás da nuca.",
+      "video": "https://www.youtube.com/watch?v=TYlT3MGn0A0",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Coice de tríceps com halteres (3x15)",
+      "subgrupo": "resistencia",
+      "equipamentos": [
+        "halteres"
+      ],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Com o tronco inclinado, estenda o braço para trás mantendo o cotovelo fixo.",
+      "video": "https://www.youtube.com/watch?v=YbX7Wd8jQ-Q",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Tríceps na barra (3x8)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "barra"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Em barras paralelas, desça e suba o corpo estendendo os cotovelos.",
+      "video": "https://www.youtube.com/watch?v=2z8JmcrW-As",
+      "exclusivoAcademia": false
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -116,7 +116,8 @@
           <option value="pernas">PERNAS</option>
           <option value="peito">PEITO</option>
           <option value="costas">COSTAS</option>
-          <option value="bracos">BRAÇOS</option>
+          <option value="biceps">BÍCEPS</option>
+          <option value="triceps">TRÍCEPS</option>
           <option value="hiit">HIIT</option>
         </select>
       </div>


### PR DESCRIPTION
## Resumo
- Separa exercícios de braço em grupos de bíceps e tríceps com seis opções cada
- Acrescenta exercícios para peito, costas e HIIT, garantindo pelo menos cinco por grupo
- Ajusta interface e carregamento de grupos para refletir as novas categorias

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3a7bcadc8832ca095ecffb46ac735