### PR TITLE
Add home equipment substitutions and expand exercise catalog

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -57,6 +57,24 @@ describe('gerarTreino', () => {
       expect(stored.grupos.length).toBe(1);
       expect(stored.grupos[0]).toBe('core');
   });
+
+    test('considera alternativas de equipamento ao filtrar exercícios', () => {
+      const select = document.getElementById('grupoSelect');
+      Array.from(select.options).forEach((opt, idx) => opt.selected = idx === 0);
+      localStorage.setItem('perfil_usuario', JSON.stringify({ equipamento: ['mochila'], locais: ['Casa'] }));
+      __setDadosTreinos({
+        core: [
+          { nome: 'halter substituido', equipamentos: ['halteres'], objetivo: ['forca'], exclusivoAcademia: false, peso: 2 }
+        ]
+      });
+
+      gerarTreino();
+      const dia = new Date().toISOString().slice(0,10);
+      const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
+      expect(stored.lista).toHaveLength(1);
+      expect(stored.lista[0].equipamentosDetalhes[0]).toMatchObject({ principal: 'halteres', utilizado: 'mochila' });
+      expect(stored.lista[0].substituicoesTexto).toMatch(/Mochila com peso/);
+    });
 });
 
 describe('sugerirGrupo', () => {

--- a/app.js
+++ b/app.js
@@ -1,6 +1,84 @@
 // 🔁 Dados dos treinos
 let dadosTreinos = {};
 
+const NOMES_EQUIPAMENTOS = {
+    halteres: "Halteres",
+    elastico: "Elástico de resistência",
+    saco: "Saco de pancada",
+    barra: "Barra fixa",
+    banco: "Banco abdominal",
+    tornozeleira: "Tornozeleira de peso",
+    corda: "Corda de pular",
+    pegador: "Pegador de mão",
+    "pinça": "Pinça de pegada",
+    toalha: "Toalha",
+    kimono: "Kimono",
+    kettlebell: "Kettlebell",
+    miniband: "Mini band",
+    suspensor: "Suspensor/TRX",
+    mochila: "Mochila com peso",
+    colchonete: "Colchonete ou tapete",
+    cadeira: "Cadeira firme",
+    garrafa: "Garrafas com peso"
+};
+
+const EQUIPAMENTOS_EQUIVALENTES = {
+    halteres: ["kettlebell", "mochila", "garrafa", "barra"],
+    kettlebell: ["halteres", "mochila"],
+    mochila: ["halteres", "kettlebell", "garrafa", "saco"],
+    garrafa: ["halteres", "mochila"],
+    elastico: ["miniband", "suspensor", "toalha"],
+    miniband: ["elastico"],
+    suspensor: ["elastico", "barra"],
+    barra: ["halteres", "suspensor"],
+    banco: ["cadeira"],
+    cadeira: ["banco"],
+    colchonete: ["toalha"],
+    toalha: ["colchonete", "elastico"],
+    saco: ["mochila"]
+};
+
+function formatEquipamento(chave) {
+    if (!chave) return "";
+    return NOMES_EQUIPAMENTOS[chave] || chave.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase());
+}
+
+function obterAlternativasEquipamento(equipamento) {
+    const alternativas = EQUIPAMENTOS_EQUIVALENTES[equipamento] || [];
+    return [...new Set(alternativas.filter(Boolean))];
+}
+
+function possuiEquipamentoOuAlternativa(equipamento, disponiveis) {
+    if (disponiveis.has(equipamento)) return true;
+    return obterAlternativasEquipamento(equipamento).some(alt => disponiveis.has(alt));
+}
+
+function detalharEquipamentos(exercicio, disponiveis) {
+    if (!exercicio?.equipamentos?.length) {
+        return { equipamentosDetalhes: [], substituicoesTexto: "" };
+    }
+
+    const detalhes = exercicio.equipamentos.map(equip => {
+        const alternativas = obterAlternativasEquipamento(equip);
+        const possuiPrincipal = disponiveis.has(equip);
+        const alternativaUsada = possuiPrincipal ? null : alternativas.find(alt => disponiveis.has(alt)) || null;
+        return {
+            principal: equip,
+            utilizado: possuiPrincipal ? equip : alternativaUsada,
+            alternativas
+        };
+    });
+
+    const substituicoes = detalhes
+        .filter(item => item.utilizado && item.utilizado !== item.principal)
+        .map(item => `${formatEquipamento(item.utilizado)} no lugar de ${formatEquipamento(item.principal)}`);
+
+    return {
+        equipamentosDetalhes: detalhes,
+        substituicoesTexto: substituicoes.join('; ')
+    };
+}
+
 async function carregarDados() {
     dadosTreinos = await getDados();
     popularSelectGrupo();
@@ -251,12 +329,13 @@ function gerarTreino() {
     const chave = "treino_" + dia;
     const perfil = getPerfil();
     const fatorI = { leve: 1, media: 2, intensa: 3 }[intensidade];
+    const equipamentosDisponiveis = new Set(perfil.equipamento || []);
 
     let base = [];
     grupos.forEach(grupo => {
         const filtrados = dadosTreinos[grupo].filter(ex => {
             const equipamentosOk = !perfil.equipamento?.length ||
-                ex.equipamentos.every(eq => perfil.equipamento.includes(eq));
+                (ex.equipamentos || []).every(eq => possuiEquipamentoOuAlternativa(eq, equipamentosDisponiveis));
             const localAcademia = perfil.locais?.includes("Academia");
             const exclusivoOk = !ex.exclusivoAcademia || localAcademia;
             const retornoOk = !perfil.retorno || ex.subgrupo === "reabilitação" || ex.peso <= 2;
@@ -270,8 +349,16 @@ function gerarTreino() {
 
     const qtd = Math.min(Math.ceil((tempo / 15) + fatorI), base.length);
     const lista = embaralharArray(base).slice(0, qtd);
+    const listaDetalhada = lista.map(exercicio => {
+        const detalhes = detalharEquipamentos(exercicio, equipamentosDisponiveis);
+        return {
+            ...exercicio,
+            equipamentosDetalhes: detalhes.equipamentosDetalhes,
+            substituicoesTexto: detalhes.substituicoesTexto
+        };
+    });
 
-    localStorage.setItem(chave, JSON.stringify({ tempo, intensidade, grupos, feitos: [], lista }));
+    localStorage.setItem(chave, JSON.stringify({ tempo, intensidade, grupos, feitos: [], lista: listaDetalhada }));
     mostrarTreino(dia, chave);
 }
 
@@ -291,14 +378,47 @@ function mostrarTreino(dia, chave = null) {
     const chaveFinal = chave || ("treino_" + dia);
     const t = JSON.parse(localStorage.getItem(chaveFinal));
     const gruposTxt = (t?.grupos || []).map(g => g.toUpperCase()).join(", ");
+    const perfil = getPerfil();
+    const equipamentosDisponiveis = new Set(perfil.equipamento || []);
+    let precisaPersistir = false;
     if (!t || !t.lista?.length) {
         document.getElementById("treino").innerHTML = `<h3>${dia} - ${gruposTxt}</h3><p>Nenhum treino encontrado</p>`;
         return;
     }
     const lista = t.lista.map((ex, i) => {
         const c = t.feitos.includes(i) ? "checked" : "";
-        return `<li><label><input type="checkbox" onchange="check(${i}, '${chaveFinal}')" ${c}/> <span onclick="abrirModalExercicio('${ex.nome.replace(/'/g, "\\'")}')" style="cursor:pointer; text-decoration:underline;">${ex.nome}</span></label></li>`;
+        const nomeSanitizado = ex.nome.replace(/'/g, "\\'");
+        const detalhes = ex.equipamentosDetalhes
+            ? { equipamentosDetalhes: ex.equipamentosDetalhes, substituicoesTexto: ex.substituicoesTexto }
+            : detalharEquipamentos(ex, equipamentosDisponiveis);
+
+        if (!ex.equipamentosDetalhes && detalhes.equipamentosDetalhes.length) {
+            t.lista[i] = { ...ex, equipamentosDetalhes: detalhes.equipamentosDetalhes, substituicoesTexto: detalhes.substituicoesTexto };
+            precisaPersistir = true;
+        }
+
+        const equipamentosTexto = (detalhes.equipamentosDetalhes || [])
+            .map(item => {
+                const principal = formatEquipamento(item.principal);
+                if (!item.alternativas.length) return principal;
+                const alternativasTxt = item.alternativas.map(formatEquipamento).join(", ");
+                return `${principal} (alternativas: ${alternativasTxt})`;
+            })
+            .join(" • ");
+
+        const equipamentoHint = equipamentosTexto
+            ? `<small class="equip-hint">${equipamentosTexto}</small>`
+            : "";
+
+        const substitutoHint = detalhes.substituicoesTexto
+            ? `<small class="equip-hint equip-hint--alternativa">${detalhes.substituicoesTexto}</small>`
+            : "";
+
+        return `<li><label><input type="checkbox" onchange="check(${i}, '${chaveFinal}')" ${c}/> <span onclick="abrirModalExercicio('${nomeSanitizado}')" style="cursor:pointer; text-decoration:underline;">${ex.nome}</span></label>${equipamentoHint}${substitutoHint}</li>`;
     }).join("");
+    if (precisaPersistir) {
+        localStorage.setItem(chaveFinal, JSON.stringify(t));
+    }
     document.getElementById("treino").innerHTML = `<h3>${dia} - ${gruposTxt}</h3><p>${t.tempo}min | ${t.intensidade}</p><ul class="checklist">${lista}</ul>`;
 }
 
@@ -463,11 +583,36 @@ function abrirModalExercicio(nome) {
     const todosExercicios = Object.values(dadosTreinos).flat();
     const ex = todosExercicios.find(e => e.nome === nome);
     if (!ex) return;
-  
+
+    const perfil = getPerfil();
+    const detalhes = detalharEquipamentos(ex, new Set(perfil.equipamento || []));
+    let html = ex.descricao || "Sem descrição.";
+
+    if (ex.equipamentos?.length) {
+        const itens = detalhes.equipamentosDetalhes.map(item => {
+            const principal = formatEquipamento(item.principal);
+            const alternativas = item.alternativas.map(formatEquipamento);
+            const alternativasTxt = alternativas.length ? ` (alternativas: ${alternativas.join(', ')})` : "";
+            const usoAlternativo = item.utilizado && item.utilizado !== item.principal
+                ? ` — use ${formatEquipamento(item.utilizado)}`
+                : "";
+            return `<li>${principal}${alternativasTxt}${usoAlternativo}</li>`;
+        }).join("");
+        if (itens) {
+            html += `<br><br><strong>Equipamentos:</strong><ul>${itens}</ul>`;
+        }
+    }
+
+    if (detalhes.substituicoesTexto) {
+        html += `<em>${detalhes.substituicoesTexto}</em>`;
+    }
+
+    html += `<br><br><a href="${ex.video}" target="_blank" style="color:blue; text-decoration:underline;">▶️ Ver vídeo no YouTube</a>`;
+
     document.getElementById("modalTitulo").textContent = ex.nome;
-    document.getElementById("modalDescricao").textContent = ex.descricao || "Sem descrição.";
+    const modalDescricao = document.getElementById("modalDescricao");
+    modalDescricao.innerHTML = html;
     document.getElementById("modalVideo").style.display = "none";
-    document.getElementById("modalDescricao").innerHTML += `<br><br><a href="${ex.video}" target="_blank" style="color:blue; text-decoration:underline;">▶️ Ver vídeo no YouTube</a>`;
 
     document.getElementById("modalExercicio").style.display = "flex";
   }

--- a/exercicios.json
+++ b/exercicios.json
@@ -138,6 +138,21 @@
       "descricao": "Durante a flexão, ao final do movimento, empurre ainda mais o chão, ativando o serrátil.",
       "video": "https://www.youtube.com/watch?v=R4h7uYgU0YQ",
       "exclusivoAcademia": false
+    },
+    {
+      "nome": "Desenvolvimento alternado com garrafas (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "garrafa"
+      ],
+      "objetivo": [
+        "forca",
+        "mobilidade"
+      ],
+      "peso": 2,
+      "descricao": "Segure garrafas cheias e pressione acima da cabeça alternando os braços, mantendo o tronco estável.",
+      "video": "https://www.youtube.com/watch?v=qEwKCR5JCog",
+      "exclusivoAcademia": false
     }
   ],
   "core": [
@@ -273,6 +288,36 @@
       "descricao": "Deitado, mantenha tronco e pernas elevadas com o abdômen totalmente contraído.",
       "video": "https://www.youtube.com/watch?v=ZJ8Zdj0OPMI",
       "exclusivoAcademia": false
+    },
+    {
+      "nome": "Prancha com mochila nas costas (3x40s)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [
+        "mochila"
+      ],
+      "objetivo": [
+        "core",
+        "resistencia"
+      ],
+      "peso": 3,
+      "descricao": "Posicione uma mochila com livros nas costas para aumentar a carga mantendo a prancha firme.",
+      "video": "https://www.youtube.com/watch?v=pSHjTRCQxIw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Elevação de quadril no colchonete (3x15)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [
+        "colchonete"
+      ],
+      "objetivo": [
+        "core",
+        "estabilidade"
+      ],
+      "peso": 2,
+      "descricao": "Deitado sobre o colchonete, eleve o quadril contraindo glúteos e abdômen, segurando 2 segundos no topo.",
+      "video": "https://www.youtube.com/watch?v=8bbE64NuDTU",
+      "exclusivoAcademia": false
     }
   ],
   "pernas": [
@@ -318,6 +363,21 @@
       "peso": 2,
       "descricao": "Com o elástico preso nas pernas, aproxime uma da outra, ativando a musculatura interna da coxa.",
       "video": "https://www.youtube.com/watch?v=GZRIxtTRz18",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Caminhada lateral com miniband (3x12 passos)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [
+        "miniband"
+      ],
+      "objetivo": [
+        "estabilidade",
+        "mobilidade"
+      ],
+      "peso": 2,
+      "descricao": "Coloque a miniband acima dos joelhos, agache levemente e dê passos laterais mantendo a tensão constante.",
+      "video": "https://www.youtube.com/watch?v=UpZDYrs0VHA",
       "exclusivoAcademia": false
     },
     {
@@ -388,6 +448,21 @@
       "peso": 4,
       "descricao": "Fique em pé com um pé apoiado atrás em um banco. Com o tronco reto, agache com a perna da frente até o joelho formar um ângulo de 90°. Volte à posição inicial e repita.",
       "video": "https://www.youtube.com/watch?v=uh1xK1oInJ4",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Afundo búlgaro na cadeira (3x10 cada lado)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "cadeira"
+      ],
+      "objetivo": [
+        "forca",
+        "equilibrio"
+      ],
+      "peso": 3,
+      "descricao": "Use uma cadeira firme para apoiar o pé de trás e realize o afundo controlando a descida e mantendo o tronco ereto.",
+      "video": "https://www.youtube.com/watch?v=2C-uNgKwPLE",
       "exclusivoAcademia": false
     },
     {
@@ -651,6 +726,21 @@
       "descricao": "Agache com os halteres nos ombros e, ao subir, empurre-os para cima em um único movimento explosivo.",
       "video": "https://www.youtube.com/watch?v=q4ZUlNfKNEw",
       "exclusivoAcademia": false
+    },
+    {
+      "nome": "Thruster com garrafas (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "garrafa"
+      ],
+      "objetivo": [
+        "forca",
+        "cardio"
+      ],
+      "peso": 3,
+      "descricao": "Use garrafas cheias como carga para realizar o agachamento seguido do empurrão acima da cabeça em movimento contínuo.",
+      "video": "https://www.youtube.com/watch?v=q4ZUlNfKNEw",
+      "exclusivoAcademia": false
     }
   ],
   "cardio": [
@@ -666,6 +756,21 @@
       "peso": 3,
       "descricao": "Pule corda em ritmo constante por 1 minuto. Mantenha os cotovelos junto ao corpo e gire a corda com os punhos.",
       "video": "https://www.youtube.com/watch?v=1BZM7e8Lyk8",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Polichinelo com miniband (3x30s)",
+      "subgrupo": "cardio",
+      "equipamentos": [
+        "miniband"
+      ],
+      "objetivo": [
+        "condicionamento",
+        "resistencia"
+      ],
+      "peso": 3,
+      "descricao": "Posicione a miniband acima dos tornozelos e execute o polichinelo mantendo a tensão da faixa durante todo o movimento.",
+      "video": "https://www.youtube.com/watch?v=s0nT_fHj4yQ",
       "exclusivoAcademia": false
     },
     {
@@ -898,6 +1003,21 @@
       "descricao": "Suba com uma perna sobre um banco ou degrau e traga a outra, depois retorne com controle.",
       "video": "https://www.youtube.com/watch?v=xM8bB1qLOuY",
       "exclusivoAcademia": false
+    },
+    {
+      "nome": "Step-up na cadeira (3x12 cada perna)",
+      "subgrupo": "estabilidade",
+      "equipamentos": [
+        "cadeira"
+      ],
+      "objetivo": [
+        "estabilidade",
+        "equilibrio"
+      ],
+      "peso": 2,
+      "descricao": "Use uma cadeira firme como apoio para subir e descer controlando o movimento e mantendo o joelho alinhado.",
+      "video": "https://www.youtube.com/watch?v=QAFD9lJe4iw",
+      "exclusivoAcademia": false
     }
   ],
   "dedos": [
@@ -1069,6 +1189,21 @@
       "descricao": "Com as mãos próximas formando um triângulo, desça o corpo mantendo os cotovelos junto ao tronco.",
       "video": "https://www.youtube.com/watch?v=J0DnG1_S92I",
       "exclusivoAcademia": false
+    },
+    {
+      "nome": "Flexão inclinada na cadeira (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "cadeira"
+      ],
+      "objetivo": [
+        "forca",
+        "estabilidade"
+      ],
+      "peso": 2,
+      "descricao": "Apoie as mãos na cadeira para reduzir a carga da flexão, mantendo o corpo alinhado durante todo o movimento.",
+      "video": "https://www.youtube.com/watch?v=J0DnG1_S92I",
+      "exclusivoAcademia": false
     }
   ],
   "costas": [
@@ -1083,6 +1218,20 @@
       ],
       "peso": 3,
       "descricao": "Com tronco inclinado, puxe os halteres em direção ao abdômen.",
+      "video": "https://www.youtube.com/watch?v=vT2GjY_Umpw",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Remada curvada com mochila (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "mochila"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Carregue uma mochila com livros e puxe em direção ao abdômen mantendo a coluna neutra.",
       "video": "https://www.youtube.com/watch?v=vT2GjY_Umpw",
       "exclusivoAcademia": false
     },
@@ -1139,6 +1288,21 @@
       "peso": 3,
       "descricao": "Apoie uma mão e um joelho em um banco e puxe o halter ao lado do tronco.",
       "video": "https://www.youtube.com/watch?v=8OO4sJ9Ek98",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Remada invertida no suspensor (3x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "suspensor"
+      ],
+      "objetivo": [
+        "forca",
+        "estabilidade"
+      ],
+      "peso": 3,
+      "descricao": "Segure as alças do suspensor com o corpo inclinado e puxe o peito em direção às mãos mantendo o corpo alinhado.",
+      "video": "https://www.youtube.com/results?search_query=remada+invertida+trx",
       "exclusivoAcademia": false
     }
   ],
@@ -1206,6 +1370,21 @@
       "peso": 3,
       "descricao": "Corra no lugar elevando os joelhos alternadamente na altura do quadril.",
       "video": "https://www.youtube.com/watch?v=8BcPHWGQO44",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Swing com kettlebell (4x20)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "kettlebell"
+      ],
+      "objetivo": [
+        "hiit",
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Empurre o quadril para trás e projete o kettlebell à frente com explosão, mantendo a coluna neutra.",
+      "video": "https://www.youtube.com/watch?v=ysqG5WZcgGQ",
       "exclusivoAcademia": false
     }
   ],
@@ -1293,6 +1472,20 @@
       "descricao": "Em pé, segure a barra com as palmas para cima e flexione os cotovelos até a altura dos ombros.",
       "video": "https://www.youtube.com/watch?v=kwG2ipFRgfo",
       "exclusivoAcademia": false
+    },
+    {
+      "nome": "Rosca direta com garrafas (3x15)",
+      "subgrupo": "resistencia",
+      "equipamentos": [
+        "garrafa"
+      ],
+      "objetivo": [
+        "resistencia"
+      ],
+      "peso": 2,
+      "descricao": "Segure garrafas cheias nas mãos e flexione os cotovelos até aproximar as mãos dos ombros mantendo os braços estáveis.",
+      "video": "https://www.youtube.com/watch?v=ykJmrZ5v0Oo",
+      "exclusivoAcademia": false
     }
   ],
   "triceps": [
@@ -1349,6 +1542,20 @@
       ],
       "peso": 3,
       "descricao": "Eleve o halter acima da cabeça e flexione os cotovelos levando o peso atrás da nuca.",
+      "video": "https://www.youtube.com/watch?v=TYlT3MGn0A0",
+      "exclusivoAcademia": false
+    },
+    {
+      "nome": "Tríceps francês com mochila (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "mochila"
+      ],
+      "objetivo": [
+        "forca"
+      ],
+      "peso": 3,
+      "descricao": "Segure uma mochila pelas alças acima da cabeça e realize o movimento de flexão e extensão dos cotovelos controlando o peso.",
       "video": "https://www.youtube.com/watch?v=TYlT3MGn0A0",
       "exclusivoAcademia": false
     },

--- a/index.html
+++ b/index.html
@@ -37,15 +37,22 @@
     <label for="equipamentosDisponiveis">Equipamentos disponíveis:</label>
     <div class="tag-group" id="equipamentos" aria-labelledby="equipamentosDisponiveis">
       <label><input type="checkbox" value="halteres"><span>🏋️ Halteres</span></label>
+      <label><input type="checkbox" value="kettlebell"><span>🛢️ Kettlebell</span></label>
       <label><input type="checkbox" value="elastico"><span>🧵 Elástico</span></label>
+      <label><input type="checkbox" value="miniband"><span>🎯 Mini band</span></label>
+      <label><input type="checkbox" value="suspensor"><span>🪢 Suspensor/TRX</span></label>
       <label><input type="checkbox" value="saco"><span>🥊 Saco de pancada</span></label>
       <label><input type="checkbox" value="barra"><span>🚧 Barra fixa</span></label>
       <label><input type="checkbox" value="banco"><span>🪑 Banco abdominal</span></label>
+      <label><input type="checkbox" value="cadeira"><span>💺 Cadeira firme</span></label>
       <label><input type="checkbox" value="tornozeleira"><span>🦵 Tornozeleira</span></label>
       <label><input type="checkbox" value="corda"><span>🪢 Corda</span></label>
       <label><input type="checkbox" value="pegador"><span>✋ Pegador</span></label>
       <label><input type="checkbox" value="pinça"><span>🧲 Pinça</span></label>
       <label><input type="checkbox" value="toalha"><span>🧼 Toalha</span></label>
+      <label><input type="checkbox" value="colchonete"><span>🧘 Colchonete/Tapete</span></label>
+      <label><input type="checkbox" value="mochila"><span>🎒 Mochila com peso</span></label>
+      <label><input type="checkbox" value="garrafa"><span>🥤 Garrafas com peso</span></label>
       <label><input type="checkbox" value="kimono"><span>🥋 Kimono</span></label>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -148,6 +148,27 @@ select:disabled {
     transform: scale(1.3);
 }
 
+.checklist .equip-hint {
+    display: block;
+    font-size: 12px;
+    color: #555;
+    margin-left: 28px;
+    margin-top: 4px;
+}
+
+.checklist .equip-hint--alternativa {
+    color: #0c5460;
+    font-weight: 600;
+}
+
+body.dark .checklist .equip-hint {
+    color: #cfd9e6;
+}
+
+body.dark .checklist .equip-hint--alternativa {
+    color: #9bd3ff;
+}
+
 /* Sugestão e treino */
 .sugestao,
 .treino {


### PR DESCRIPTION
## Summary
- implement equipment equivalence mapping so exercises accept home-friendly alternativas, persist substitution hints and show them in the treino checklist/modal
- extend the profile form and styling to list new itens como kettlebell, miniband, mochila, garrafas e cadeira for home practice
- enrich exercicios.json with variações focadas em treinos domésticos aproveitando os novos equipamentos

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9931d8ed0832ca0fd15b238897f35