### PR TITLE
Adicionar opção "Academia only" ao Gerar Treino do Dia

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -13,6 +13,7 @@ describe('gerarTreino', () => {
     document.body.innerHTML = `
       <input id="tempo" value="30" />
       <select id="intensidade"><option value="media" selected>media</option></select>
+      <input id="academiaOnlyToggle" type="checkbox" />
       <select id="grupoSelect" multiple>
         <option value="core" selected>core</option>
         <option value="cardio" selected>cardio</option>
@@ -91,6 +92,26 @@ describe('gerarTreino', () => {
       const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
       expect(stored.lista).toHaveLength(1);
       expect(stored.lista[0].nome).toBe('puxada');
+    });
+
+    test('gera treino com exercícios exclusivos de academia quando academia only está ativo', () => {
+      const select = document.getElementById('grupoSelect');
+      Array.from(select.options).forEach((opt, idx) => opt.selected = idx === 0);
+      document.getElementById('academiaOnlyToggle').checked = true;
+      localStorage.setItem('perfil_usuario', JSON.stringify({ equipamento: [], locais: ['Academia'] }));
+      __setDadosTreinos({
+        core: [
+          { nome: 'agachamento livre', equipamentos: [], objetivo: ['forca'], exclusivoAcademia: false, peso: 2 },
+          { nome: 'leg press', equipamentos: [], objetivo: ['forca'], exclusivoAcademia: true, peso: 3 }
+        ]
+      });
+
+      gerarTreino();
+      const dia = new Date().toISOString().slice(0,10);
+      const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
+      expect(stored.lista).toHaveLength(1);
+      expect(stored.lista[0].nome).toBe('leg press');
+      expect(stored.modoLocal).toBe('academia_only');
     });
 });
 

--- a/app.js
+++ b/app.js
@@ -120,6 +120,20 @@ function atualizarVisibilidadeEquipamentosAcademia() {
     }
 }
 
+function atualizarVisibilidadeAcademiaOnly() {
+    const container = document.getElementById("academiaOnlyContainer");
+    const toggle = document.getElementById("academiaOnlyToggle");
+    if (!container || !toggle) return;
+
+    const perfil = getPerfil();
+    const temAcademia = Array.isArray(perfil.locais) && perfil.locais.includes("Academia");
+    container.style.display = temAcademia ? "block" : "none";
+
+    if (!temAcademia) {
+        toggle.checked = false;
+    }
+}
+
 async function carregarDados() {
     dadosTreinos = await getDados();
     popularSelectGrupo();
@@ -227,6 +241,7 @@ function editarPerfil() {
 
     document.getElementById("modoRetorno").checked = perfil.retorno || false;
     atualizarVisibilidadeEquipamentosAcademia();
+    atualizarVisibilidadeAcademiaOnly();
 
     exibirCard("perfilCard");
 }
@@ -391,16 +406,18 @@ function gerarTreino() {
     const perfil = getPerfil();
     const fatorI = { leve: 1, media: 2, intensa: 3 }[intensidade];
     const equipamentosDisponiveis = new Set(perfil.equipamento || []);
+    const academiaOnly = document.getElementById("academiaOnlyToggle")?.checked;
+    const localAcademia = perfil.locais?.includes("Academia");
 
     let base = [];
     grupos.forEach(grupo => {
         const filtrados = dadosTreinos[grupo].filter(ex => {
             const equipamentosOk = !perfil.equipamento?.length ||
                 (ex.equipamentos || []).every(eq => possuiEquipamentoOuAlternativa(eq, equipamentosDisponiveis));
-            const localAcademia = perfil.locais?.includes("Academia");
             const exclusivoOk = !ex.exclusivoAcademia || localAcademia;
+            const academiaOnlyOk = !academiaOnly || (localAcademia && ex.exclusivoAcademia);
             const retornoOk = !perfil.retorno || ex.subgrupo === "reabilitação" || ex.peso <= 2;
-            return equipamentosOk && exclusivoOk && retornoOk;
+            return equipamentosOk && exclusivoOk && academiaOnlyOk && retornoOk;
         });
         base = base.concat(filtrados);
     });
@@ -419,7 +436,14 @@ function gerarTreino() {
         };
     });
 
-    localStorage.setItem(chave, JSON.stringify({ tempo, intensidade, grupos, feitos: [], lista: listaDetalhada }));
+    localStorage.setItem(chave, JSON.stringify({
+        tempo,
+        intensidade,
+        grupos,
+        feitos: [],
+        lista: listaDetalhada,
+        modoLocal: academiaOnly ? "academia_only" : "misto"
+    }));
     mostrarTreino(dia, chave);
 }
 
@@ -635,6 +659,7 @@ async function iniciar(perfil) {
     document.getElementById("intensidade").disabled = false;
     document.querySelector("button[onclick*='gerarTreino']").disabled = false;
     document.querySelector("button[onclick*='sugerirGrupo']").disabled = false;
+    atualizarVisibilidadeAcademiaOnly();
     exibirCard("mainCard");
 
     await carregarDados();
@@ -727,6 +752,7 @@ window.onload = async () => {
         input.addEventListener("change", atualizarVisibilidadeEquipamentosAcademia);
     });
     atualizarVisibilidadeEquipamentosAcademia();
+    atualizarVisibilidadeAcademiaOnly();
 
 };
 

--- a/index.html
+++ b/index.html
@@ -152,6 +152,10 @@
     <div class="treino" id="treino"></div>
 
     <hr style="margin: 20px 0;" />
+    <label id="academiaOnlyContainer" style="display:none; margin-bottom: 12px;">
+      <input type="checkbox" id="academiaOnlyToggle">
+      Gerar treino do dia <strong>Academia only</strong>
+    </label>
     <button class="button" onclick="gerarTreino()">✅ Gerar Novo Treino do Dia</button>
     <button class="button" onclick="sugerirGrupo()">🔄 Sugerir Outro Grupo</button>
     <button class="button" onclick="editarPerfil()">✏️ Editar Perfil</button>


### PR DESCRIPTION
### Motivation
- Permitir gerar um treino do dia que contenha apenas exercícios marcados como `exclusivoAcademia` para usuários que treinam na Academia. 
- Evitar confusão ao selecionar equipamentos/treinos quando o usuário quer foco exclusivo em aparelhos de academia. 
- Registrar o modo do treino para rastreabilidade do histórico (`modoLocal`).

### Description
- Adiciona um checkbox visível apenas para perfis com local `Academia` no `index.html` (`academiaOnlyContainer` / `academiaOnlyToggle`).
- Implementa `atualizarVisibilidadeAcademiaOnly()` e integra essa lógica em `editarPerfil`, `iniciar` e no `window.onload` para manter a UI sincronizada com o perfil. 
- Atualiza `gerarTreino()` para ler o toggle, aplicar o filtro que exige `exclusivoAcademia` quando ativo, e persistir o campo `modoLocal` no objeto salvo no `localStorage`.
- Inclui teste unitário em `__tests__/app.test.js` cobrindo o comportamento `academia only` e adiciona o elemento de teste `academiaOnlyToggle` no setup dos testes.

### Testing
- Executado `npm test -- --runInBand` em ambiente de CI local com Jest. 
- Resultado: todos os testes passaram (`1 test suite, 8 testes — todos passaram`).
- Os testes cobrem geração de treino, filtragem por equipamento/academia e persistência do campo `modoLocal`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df78bce270832ca8f30df861fa1be2)