### PR TITLE
fix: evitar treino vazio no modo academia only

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -13,6 +13,7 @@ describe('gerarTreino', () => {
     document.body.innerHTML = `
       <input id="tempo" value="30" />
       <select id="intensidade"><option value="media" selected>media</option></select>
+      <input id="academiaOnlyToggle" type="checkbox" />
       <select id="grupoSelect" multiple>
         <option value="core" selected>core</option>
         <option value="cardio" selected>cardio</option>
@@ -91,6 +92,45 @@ describe('gerarTreino', () => {
       const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
       expect(stored.lista).toHaveLength(1);
       expect(stored.lista[0].nome).toBe('puxada');
+    });
+
+    test('gera treino com exercícios exclusivos de academia quando academia only está ativo', () => {
+      const select = document.getElementById('grupoSelect');
+      Array.from(select.options).forEach((opt, idx) => opt.selected = idx === 0);
+      document.getElementById('academiaOnlyToggle').checked = true;
+      localStorage.setItem('perfil_usuario', JSON.stringify({ equipamento: [], locais: ['Academia'] }));
+      __setDadosTreinos({
+        core: [
+          { nome: 'agachamento livre', equipamentos: [], objetivo: ['forca'], exclusivoAcademia: false, peso: 2 },
+          { nome: 'leg press', equipamentos: [], objetivo: ['forca'], exclusivoAcademia: true, peso: 3 }
+        ]
+      });
+
+      gerarTreino();
+      const dia = new Date().toISOString().slice(0,10);
+      const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
+      expect(stored.lista).toHaveLength(1);
+      expect(stored.lista[0].nome).toBe('leg press');
+      expect(stored.modoLocal).toBe('academia_only');
+    });
+
+    test('faz fallback para exercícios gerais quando academia only não encontra exclusivos', () => {
+      const select = document.getElementById('grupoSelect');
+      Array.from(select.options).forEach((opt, idx) => opt.selected = idx === 0);
+      document.getElementById('academiaOnlyToggle').checked = true;
+      localStorage.setItem('perfil_usuario', JSON.stringify({ equipamento: [], locais: ['Academia'] }));
+      __setDadosTreinos({
+        core: [
+          { nome: 'prancha', equipamentos: [], objetivo: ['core'], exclusivoAcademia: false, peso: 2 }
+        ]
+      });
+
+      gerarTreino();
+      const dia = new Date().toISOString().slice(0,10);
+      const stored = JSON.parse(localStorage.getItem(`treino_${dia}`));
+      expect(stored.lista).toHaveLength(1);
+      expect(stored.lista[0].nome).toBe('prancha');
+      expect(stored.modoLocal).toBe('academia_only');
     });
 });
 

--- a/app.js
+++ b/app.js
@@ -120,6 +120,20 @@ function atualizarVisibilidadeEquipamentosAcademia() {
     }
 }
 
+function atualizarVisibilidadeAcademiaOnly() {
+    const container = document.getElementById("academiaOnlyContainer");
+    const toggle = document.getElementById("academiaOnlyToggle");
+    if (!container || !toggle) return;
+
+    const perfil = getPerfil();
+    const temAcademia = Array.isArray(perfil.locais) && perfil.locais.includes("Academia");
+    container.style.display = temAcademia ? "block" : "none";
+
+    if (!temAcademia) {
+        toggle.checked = false;
+    }
+}
+
 async function carregarDados() {
     dadosTreinos = await getDados();
     popularSelectGrupo();
@@ -227,6 +241,7 @@ function editarPerfil() {
 
     document.getElementById("modoRetorno").checked = perfil.retorno || false;
     atualizarVisibilidadeEquipamentosAcademia();
+    atualizarVisibilidadeAcademiaOnly();
 
     exibirCard("perfilCard");
 }
@@ -391,19 +406,33 @@ function gerarTreino() {
     const perfil = getPerfil();
     const fatorI = { leve: 1, media: 2, intensa: 3 }[intensidade];
     const equipamentosDisponiveis = new Set(perfil.equipamento || []);
+    const academiaOnly = document.getElementById("academiaOnlyToggle")?.checked;
+    const localAcademia = perfil.locais?.includes("Academia");
 
     let base = [];
-    grupos.forEach(grupo => {
-        const filtrados = dadosTreinos[grupo].filter(ex => {
-            const equipamentosOk = !perfil.equipamento?.length ||
-                (ex.equipamentos || []).every(eq => possuiEquipamentoOuAlternativa(eq, equipamentosDisponiveis));
-            const localAcademia = perfil.locais?.includes("Academia");
-            const exclusivoOk = !ex.exclusivoAcademia || localAcademia;
-            const retornoOk = !perfil.retorno || ex.subgrupo === "reabilitação" || ex.peso <= 2;
-            return equipamentosOk && exclusivoOk && retornoOk;
+    const montarBase = (somenteExclusivoAcademia) => {
+        let acumulado = [];
+        grupos.forEach(grupo => {
+            const filtrados = dadosTreinos[grupo].filter(ex => {
+                const equipamentosOk = !perfil.equipamento?.length ||
+                    (ex.equipamentos || []).every(eq => possuiEquipamentoOuAlternativa(eq, equipamentosDisponiveis));
+                const exclusivoOk = !ex.exclusivoAcademia || localAcademia;
+                const academiaOnlyOk = !somenteExclusivoAcademia || (localAcademia && ex.exclusivoAcademia);
+                const retornoOk = !perfil.retorno || ex.subgrupo === "reabilitação" || ex.peso <= 2;
+                return equipamentosOk && exclusivoOk && academiaOnlyOk && retornoOk;
+            });
+            acumulado = acumulado.concat(filtrados);
         });
-        base = base.concat(filtrados);
-    });
+        return acumulado;
+    };
+
+    base = montarBase(academiaOnly);
+
+    // Fallback: se não houver exercícios marcados como exclusivos de academia,
+    // usa exercícios gerais compatíveis com o perfil para não deixar o treino vazio.
+    if (academiaOnly && base.length === 0) {
+        base = montarBase(false);
+    }
 
     // Remove duplicados pelo nome
     base = Array.from(new Map(base.map(ex => [ex.nome, ex])).values());
@@ -419,7 +448,14 @@ function gerarTreino() {
         };
     });
 
-    localStorage.setItem(chave, JSON.stringify({ tempo, intensidade, grupos, feitos: [], lista: listaDetalhada }));
+    localStorage.setItem(chave, JSON.stringify({
+        tempo,
+        intensidade,
+        grupos,
+        feitos: [],
+        lista: listaDetalhada,
+        modoLocal: academiaOnly ? "academia_only" : "misto"
+    }));
     mostrarTreino(dia, chave);
 }
 
@@ -635,6 +671,7 @@ async function iniciar(perfil) {
     document.getElementById("intensidade").disabled = false;
     document.querySelector("button[onclick*='gerarTreino']").disabled = false;
     document.querySelector("button[onclick*='sugerirGrupo']").disabled = false;
+    atualizarVisibilidadeAcademiaOnly();
     exibirCard("mainCard");
 
     await carregarDados();
@@ -727,6 +764,7 @@ window.onload = async () => {
         input.addEventListener("change", atualizarVisibilidadeEquipamentosAcademia);
     });
     atualizarVisibilidadeEquipamentosAcademia();
+    atualizarVisibilidadeAcademiaOnly();
 
 };
 

--- a/index.html
+++ b/index.html
@@ -152,6 +152,10 @@
     <div class="treino" id="treino"></div>
 
     <hr style="margin: 20px 0;" />
+    <label id="academiaOnlyContainer" style="display:none; margin-bottom: 12px;">
+      <input type="checkbox" id="academiaOnlyToggle">
+      Gerar treino do dia <strong>Academia only</strong>
+    </label>
     <button class="button" onclick="gerarTreino()">✅ Gerar Novo Treino do Dia</button>
     <button class="button" onclick="sugerirGrupo()">🔄 Sugerir Outro Grupo</button>
     <button class="button" onclick="editarPerfil()">✏️ Editar Perfil</button>


### PR DESCRIPTION
## Resumo
- corrige a geração de treino no modo `Academia only` para evitar lista vazia quando não existir exercício marcado como `exclusivoAcademia`
- refatora o filtro de `gerarTreino()` com uma função `montarBase(...)` e aplica fallback automático para exercícios gerais compatíveis
- adiciona teste cobrindo o cenário de fallback (modo academia only ativo sem exclusivos)

## Por que
Na prática, muitos grupos podem não ter exercícios com `exclusivoAcademia: true`. O comportamento anterior resultava em treino vazio ao ativar a opção.

## Testes
- `npm test -- --runInBand` (9 testes passando)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df78bce270832ca8f30df861fa1be2)