### PR TITLE
feat: suporte a imagem opcional no modal de exercício

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,10 @@ Distribuído sob a licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais det
 ---
 
 > "Na caverna que você teme entrar está o treino que pode te transformar."
+
+
+## Convenção de imagens de exercícios
+
+- Campo opcional no `exercicios.json`: `imagem`.
+- Aceita caminho relativo (ex.: `assets/exercicios/rosca-scott-maquina.jpg`) ou URL externa.
+- Padrão recomendado para arquivos locais: `assets/exercicios/<slug-do-exercicio>.jpg`.

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,4 +1,4 @@
-const { gerarTreino, calcularSequenciaDias, __setDadosTreinos, sugerirGrupo, expandirEquipamentosSelecionados } = require('../app');
+const { gerarTreino, calcularSequenciaDias, __setDadosTreinos, sugerirGrupo, expandirEquipamentosSelecionados, abrirModalExercicio } = require('../app');
 
 describe('calcularSequenciaDias', () => {
   test('calcula maior sequencia', () => {
@@ -155,5 +155,45 @@ describe('sugerirGrupo', () => {
     await sugerirGrupo();
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+
+describe('abrirModalExercicio', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <div id="modalExercicio" style="display:none;"></div>
+      <h3 id="modalTitulo"></h3>
+      <img id="modalImagem" style="display:none;" />
+      <p id="modalDescricao"></p>
+      <iframe id="modalVideo" style="display:none;"></iframe>
+    `;
+    localStorage.setItem('perfil_usuario', JSON.stringify({ equipamento: [], locais: ['Casa'] }));
+  });
+
+  test('exibe imagem quando o exercício possui campo imagem', () => {
+    __setDadosTreinos({
+      core: [{ nome: 'prancha', descricao: 'desc', video: 'https://example.com', imagem: 'assets/exercicios/prancha.jpg', equipamentos: [] }]
+    });
+
+    abrirModalExercicio('prancha');
+
+    const imagem = document.getElementById('modalImagem');
+    expect(imagem.style.display).toBe('block');
+    expect(imagem.getAttribute('src')).toBe('assets/exercicios/prancha.jpg');
+    expect(imagem.getAttribute('alt')).toContain('prancha');
+  });
+
+  test('oculta imagem quando o exercício não possui campo imagem', () => {
+    __setDadosTreinos({
+      core: [{ nome: 'canivete', descricao: 'desc', video: 'https://example.com', equipamentos: [] }]
+    });
+
+    abrirModalExercicio('canivete');
+
+    const imagem = document.getElementById('modalImagem');
+    expect(imagem.style.display).toBe('none');
+    expect(imagem.getAttribute('src')).toBeNull();
   });
 });

--- a/app.js
+++ b/app.js
@@ -708,6 +708,18 @@ function abrirModalExercicio(nome) {
     html += `<br><br><a href="${ex.video}" target="_blank" style="color:blue; text-decoration:underline;">▶️ Ver vídeo no YouTube</a>`;
 
     document.getElementById("modalTitulo").textContent = ex.nome;
+    const modalImagem = document.getElementById("modalImagem");
+    if (modalImagem) {
+        if (ex.imagem) {
+            modalImagem.src = ex.imagem;
+            modalImagem.alt = `Imagem do exercício ${ex.nome}`;
+            modalImagem.style.display = "block";
+        } else {
+            modalImagem.removeAttribute("src");
+            modalImagem.style.display = "none";
+        }
+    }
+
     const modalDescricao = document.getElementById("modalDescricao");
     modalDescricao.innerHTML = html;
     document.getElementById("modalVideo").style.display = "none";
@@ -718,6 +730,11 @@ function abrirModalExercicio(nome) {
   function fecharModal() {
     document.getElementById("modalExercicio").style.display = "none";
     document.getElementById("modalVideo").src = ""; // Para parar o vídeo
+    const modalImagem = document.getElementById("modalImagem");
+    if (modalImagem) {
+        modalImagem.removeAttribute("src");
+        modalImagem.style.display = "none";
+    }
   }
 
 // 🌙 Tema escuro
@@ -778,6 +795,7 @@ if (typeof module !== 'undefined') {
     embaralharArray,
     sugerirGrupo,
     __setDadosTreinos: d => dadosTreinos = d,
-    expandirEquipamentosSelecionados
+    expandirEquipamentosSelecionados,
+    abrirModalExercicio
   };
 }

--- a/exercicios.json
+++ b/exercicios.json
@@ -11,6 +11,7 @@
       "peso": 1,
       "descricao": "Fique encostado na parede, com braços dobrados a 90°, deslize-os para cima e para baixo sem tirar as costas da parede.",
       "video": "https://www.youtube.com/watch?v=Im3DTNGjMJo",
+      "imagem": "assets/exercicios/wall-angels.jpg",
       "exclusivoAcademia": false
     },
     {

--- a/index.html
+++ b/index.html
@@ -245,6 +245,7 @@
   <div class="modal-content">
     <span class="close" onclick="fecharModal()">&times;</span>
     <h3 id="modalTitulo"></h3>
+    <img id="modalImagem" class="modal-imagem" style="display:none;" alt="Imagem do exercício" />
     <p id="modalDescricao"></p>
     <iframe id="modalVideo" width="100%" height="240" style="border:none; display: none;" allowfullscreen></iframe>
   </div>

--- a/style.css
+++ b/style.css
@@ -315,7 +315,24 @@ body.dark .resumoHistorico li strong {
     box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   }
   
-  .modal .close {
+  
+.modal-imagem {
+    width: 100%;
+    max-width: 420px;
+    max-height: 220px;
+    object-fit: cover;
+    border: 1px solid #d6dce5;
+    border-radius: 10px;
+    margin: 10px 0 14px;
+    background: #f3f5f8;
+}
+
+body.dark .modal-imagem {
+    border-color: #3a4659;
+    background: #1c2330;
+}
+
+.modal .close {
     float: right;
     font-size: 24px;
     cursor: pointer;


### PR DESCRIPTION
### Motivation
- Melhorar a experiência do modal de exercício exibindo uma imagem ilustrativa quando disponível para facilitar identificação visual do movimento. 
- Garantir que a ausência da imagem não quebre o layout do modal, tratando o campo como opcional no schema de exercícios.

### Description
- Estende o schema adicionando o campo opcional `imagem` em `exercicios.json` (aceita caminho relativo ou URL) e inclui um exemplo para `Wall Angels`.
- Insere o elemento `<img id="modalImagem" class="modal-imagem" />` no modal em `index.html` antes da descrição. 
- Atualiza `abrirModalExercicio(nome)` em `app.js` para definir `src`/`alt` e mostrar/ocultar `#modalImagem` conforme `ex.imagem`, e limpa o estado da imagem em `fecharModal`; também exporta `abrirModalExercicio` para testes.
- Adiciona estilos em `style.css` para `.modal-imagem` com largura responsiva, `max-height`, `object-fit: cover`, borda, espaçamento e suporte a tema escuro.
- Documenta a convenção de assets no `README.md` recomendando a pasta `assets/exercicios/` e nomes por slug do exercício.
- Atualiza `__tests__/app.test.js` adicionando testes para o caso com imagem (imagem visível e `src`/`alt` corretos) e sem imagem (imagem ocultada e `src` removido).

### Testing
- Rodei a suíte de testes com `npm test -- --runInBand` e todos os testes unitários passaram com sucesso. 
- Os novos testes para `abrirModalExercicio` (exibe imagem / oculta quando ausente) foram executados e estão verdes junto com o restante da suíte.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33b8d6270832cb4a86bbb95416b50)