### PR TITLE
Add gym machine exercises and support for 'cadeira_adutora' equipment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ O **Caverna BJJ** é um app leve, responsivo e offline para gerar treinos funcio
   - Pode ser adicionado à tela inicial no celular
   - Funciona offline com dados salvos no dispositivo
 
+- 🏢 **Cobertura de máquinas de academia**
+  - Novos exercícios contemplam equipamentos como cadeira adutora e máquina guiada
+  - Mantém compatibilidade com filtros de equipamentos no gerador
+
 - 🔄 **Modo Retorno/Beginner**
   - Ative no perfil para focar em exercícios leves e de reabilitação
   - Seleciona apenas movimentos com `subgrupo` "reabilitação" ou `peso` ≤ 2

--- a/app.js
+++ b/app.js
@@ -45,6 +45,7 @@ const EQUIPAMENTOS_ACADEMIA_MAP = {
     leg_press: ["banco"],
     cadeira_extensora: ["banco"],
     cadeira_flexora: ["banco"],
+    cadeira_adutora: ["miniband"],
     esteira: ["corda"],
     bike_ergometrica: ["corda"]
 };

--- a/exercicios.json
+++ b/exercicios.json
@@ -566,6 +566,53 @@
       "descricao": "Deite-se na máquina e flexione os joelhos até contrair posteriores de coxa, retornando lentamente.",
       "video": "https://www.youtube.com/watch?v=1Tq3QdYUuHs",
       "exclusivoAcademia": true
+    },
+    {
+      "nome": "Adução na máquina (4x12)",
+      "subgrupo": "isolamento",
+      "equipamentos": [
+        "cadeira_adutora"
+      ],
+      "objetivo": [
+        "forca",
+        "adutores",
+        "hipertrofia"
+      ],
+      "peso": 4,
+      "descricao": "Sente-se na cadeira adutora, ajuste o encosto e as almofadas na parte interna das coxas. Feche as pernas contra a resistência, contraindo os adutores, e retorne devagar sem perder o controle.",
+      "video": "https://www.youtube.com/watch?v=yB_vNfN4mP8",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Cadeira extensora unilateral (3x12 por perna)",
+      "subgrupo": "isolamento",
+      "equipamentos": [
+        "cadeira_extensora"
+      ],
+      "objetivo": [
+        "forca",
+        "hipertrofia",
+        "equilibrio"
+      ],
+      "peso": 4,
+      "descricao": "Sente-se na cadeira extensora com boa postura. Estenda uma perna por vez até quase travar o joelho, contraindo quadríceps, e retorne de forma controlada.",
+      "video": "https://www.youtube.com/watch?v=YyvSfVjQeL0",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Leg press 45° (4x10)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "leg_press"
+      ],
+      "objetivo": [
+        "forca",
+        "hipertrofia"
+      ],
+      "peso": 5,
+      "descricao": "Posicione os pés na largura dos ombros na plataforma. Flexione joelhos até o limite confortável e empurre sem estender totalmente, mantendo lombar apoiada.",
+      "video": "https://www.youtube.com/watch?v=IZxyjW7MPJQ",
+      "exclusivoAcademia": true
     }
   ],
   "fullbody": [
@@ -800,6 +847,22 @@
       "peso": 4,
       "descricao": "Com a barra próxima às canelas, estenda joelhos e quadril mantendo coluna neutra para trabalhar corpo inteiro.",
       "video": "https://www.youtube.com/watch?v=ytGaGIn3SjE",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Remada baixa na máquina (3x12)",
+      "subgrupo": "forca",
+      "equipamentos": [
+        "maquina_polia"
+      ],
+      "objetivo": [
+        "forca",
+        "postura",
+        "condicionamento"
+      ],
+      "peso": 4,
+      "descricao": "Sente-se na máquina, mantenha peito aberto e puxe a alça em direção ao abdômen, aproximando escápulas. Retorne com controle sem perder alinhamento.",
+      "video": "https://www.youtube.com/watch?v=GZbfZ033f74",
       "exclusivoAcademia": true
     }
   ],
@@ -1714,6 +1777,36 @@
       "peso": 3,
       "descricao": "Com tronco apoiado no banco inclinado, realize rosca martelo alternada sem balançar os ombros.",
       "video": "https://www.youtube.com/watch?v=zC3nLlEvin4",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Rosca Scott na máquina (4x10)",
+      "subgrupo": "isolamento",
+      "equipamentos": [
+        "maquina_guiada"
+      ],
+      "objetivo": [
+        "forca",
+        "hipertrofia"
+      ],
+      "peso": 4,
+      "descricao": "Ajuste o banco Scott para apoiar totalmente os braços. Com pegada confortável, flexione os cotovelos elevando a carga sem tirar o braço do apoio e desça lentamente até quase estender.",
+      "video": "https://www.youtube.com/watch?v=9M9tV5j7xP8",
+      "exclusivoAcademia": true
+    },
+    {
+      "nome": "Rosca na polia baixa com barra reta (3x12)",
+      "subgrupo": "isolamento",
+      "equipamentos": [
+        "maquina_polia"
+      ],
+      "objetivo": [
+        "forca",
+        "hipertrofia"
+      ],
+      "peso": 4,
+      "descricao": "Em pé, segure a barra reta na polia baixa com cotovelos próximos ao tronco. Flexione os cotovelos elevando a barra e desça lentamente sem balançar o corpo.",
+      "video": "https://www.youtube.com/watch?v=kwG2ipFRgfo",
       "exclusivoAcademia": true
     }
   ],

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
         <label><input type="checkbox" value="leg_press"><span>🦿 Leg press</span></label>
         <label><input type="checkbox" value="cadeira_extensora"><span>🪑 Cadeira extensora</span></label>
         <label><input type="checkbox" value="cadeira_flexora"><span>🪑 Cadeira flexora</span></label>
+        <label><input type="checkbox" value="cadeira_adutora"><span>🦵 Cadeira adutora</span></label>
         <label><input type="checkbox" value="esteira"><span>🏃 Esteira</span></label>
         <label><input type="checkbox" value="bike_ergometrica"><span>🚴 Bike ergométrica</span></label>
       </div>


### PR DESCRIPTION
### Motivation
- Expand the exercise database to include common gym-machine movements so workouts generated for gym sessions are more relevant and complete.
- Ensure the UI and equipment-matching logic recognize new machine equipment (like `cadeira_adutora`) so filters and substitution logic remain consistent.
- Update documentation to advertise broader gym equipment coverage and compatibility with the generator.

### Description
- Added a brief note in `README.md` about coverage for gym machines and compatibility with equipment filters. 
- Registered `cadeira_adutora` in the gym equipment map in `app.js` by adding it to `EQUIPAMENTOS_ACADEMIA_MAP`. 
- Added a checkbox for `cadeira_adutora` to the gym equipment section in `index.html` so users can mark availability of that machine. 
- Extended `exercicios.json` with several new gym-only exercises (for example `Adução na máquina (4x12)`, `Cadeira extensora unilateral`, `Leg press 45°`, `Remada baixa na máquina`, `Rosca Scott na máquina`, and `Rosca na polia baixa`) including metadata like `equipamentos`, `objetivo`, `peso`, `descricao`, `video`, and `exclusivoAcademia: true`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33b857d3c832c9b0a200b32fa63fd)